### PR TITLE
Add ADR for extending the TOSCA YAML model

### DIFF
--- a/docs/adr/0001-extend-tosca-yaml-model.md
+++ b/docs/adr/0001-extend-tosca-yaml-model.md
@@ -1,0 +1,45 @@
+# Extend TOSCA YAML model to a full in-memory model
+
+As a programmer, I want to access the complete YAML model and not be forced to traverse through all files.
+
+For instance, `TNodeTemplate.java` offers `public QName getType() {`, but one wants `public TNodeType getType()`.
+
+## Considered Alternatives
+
+* Inherit from plain data model and add transparent resolution
+* New data model
+* Eclipse EMF
+
+## Decision Outcome
+
+* Chosen Alternative: Inherit from plain data model and add transparent resolution
+* Comes out best (see below)
+
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### Inherit from plain data model and add transparent resolution
+
+A new model with all classes in a different package inheriting from all model classes.
+Each class gets new methods.
+For the type example:
+
+- `public TNodeType getTypeResolved()`
+- `public setType(TNodeType nodeType)`
+
+This model is offered by a new repository implementation, which resolves the objects on demand.
+
+* `+` Transparent for the user
+* `+` `org.eclipse.winery.model.tosca.yaml` reused
+* `-` EMF Resource Set handling is implemented manually
+
+### New data model
+
+* `+` Clean data model
+* `-` Much code from `org.eclipse.winery.model.tosca.yaml` duplicated
+
+### Eclipse EMF
+
+* `+` [Resource Sets](http://download.eclipse.org/modeling/emf/emf/javadoc/2.5.0/org/eclipse/emf/ecore/resource/ResourceSet.html) handling does this transparent solution
+* `-` Changing all the model to EMF causes huge overhead
+* `-` Getting EMF into non-OSGi projects is hard


### PR DESCRIPTION
This PR adds the result of the discussion mainly @hnicke and me had about the TOSCA YAML data model.

<s>It also adds [MADR](https://github.com/adr/madr), which should be used to document architectural decisions. More information on architectural decision records is available at <http://adr.github.io/>.</s>