### PR TITLE
Implemented Artifact Handling

### DIFF
--- a/core/src/main/java/org/opentosca/toscana/core/api/ArtifactController.java
+++ b/core/src/main/java/org/opentosca/toscana/core/api/ArtifactController.java
@@ -1,7 +1,19 @@
 package org.opentosca.toscana.core.api;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.opentosca.toscana.core.util.Preferences;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.hateoas.Link;
@@ -10,13 +22,12 @@ import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.core.Relation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/artifacts")
@@ -25,13 +36,12 @@ public class ArtifactController {
     @Value("${toscana.mappings.enable-artifact-list}")
     public boolean enableArtifactList;
 
-    private final Preferences preferences;
+    private final ArtifactManagementService ams;
 
     @Autowired
-    public ArtifactController(Preferences preferences) {
-        this.preferences = preferences;
+    public ArtifactController(ArtifactManagementService ams) {
+        this.ams = ams;
     }
-
 
     @RequestMapping(value = {"/", ""}, method = RequestMethod.GET, produces = "application/hal+json")
     public ResponseEntity<Resources<FileResource>> listFiles(HttpServletRequest request) throws Exception {
@@ -39,7 +49,7 @@ public class ArtifactController {
             throw new IllegalAccessException("This operation has been disabled by the administrator");
         }
         List<FileResource> resources = new ArrayList<>();
-        for (File file : preferences.getArtifactDir().listFiles()) {
+        for (File file : ams.getArtifactDir().listFiles()) {
             if (file.isFile()) {
                 resources.add(
                     new FileResource(
@@ -62,7 +72,7 @@ public class ArtifactController {
         @PathVariable("filename") String filename,
         HttpServletResponse response
     ) throws IOException {
-        File f = new File(preferences.getArtifactDir(), filename);
+        File f = new File(ams.getArtifactDir(), filename);
         if (!f.exists()) {
             throw new FileNotFoundException(f.getName() + " not found!");
         }

--- a/core/src/main/java/org/opentosca/toscana/core/api/ArtifactController.java
+++ b/core/src/main/java/org/opentosca/toscana/core/api/ArtifactController.java
@@ -11,7 +11,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,10 +36,10 @@ public class ArtifactController {
     @Value("${toscana.mappings.enable-artifact-list}")
     public boolean enableArtifactList;
 
-    private final ArtifactManagementService ams;
+    private final ArtifactService ams;
 
     @Autowired
-    public ArtifactController(ArtifactManagementService ams) {
+    public ArtifactController(ArtifactService ams) {
         this.ams = ams;
     }
 

--- a/core/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
@@ -1,18 +1,5 @@
 package org.opentosca.toscana.core.csar;
 
-import org.apache.commons.io.FileUtils;
-import javax.annotation.PostConstruct;
-
-import org.opentosca.toscana.core.transformation.Transformation;
-import org.opentosca.toscana.core.transformation.TransformationDao;
-import org.opentosca.toscana.core.util.Preferences;
-import org.opentosca.toscana.core.util.ZipUtility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.stereotype.Repository;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,6 +8,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipInputStream;
+
+import javax.annotation.PostConstruct;
+
+import org.opentosca.toscana.core.transformation.Transformation;
+import org.opentosca.toscana.core.transformation.TransformationDao;
+import org.opentosca.toscana.core.util.Preferences;
+import org.opentosca.toscana.core.util.ZipUtility;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public class CsarFilesystemDao implements CsarDao {
@@ -42,7 +43,6 @@ public class CsarFilesystemDao implements CsarDao {
     // a map containing all csars. it should be kept in sync with the status of the file system
     private final Map<String, Csar> csarMap = new HashMap<>();
 
-
     @Autowired
     public CsarFilesystemDao(Preferences preferences, @Lazy TransformationDao transformationDao) {
         this.dataDir = preferences.getDataDir();
@@ -54,7 +54,6 @@ public class CsarFilesystemDao implements CsarDao {
             }
         }
 
-        readFromDisk();
         this.transformationDao = transformationDao;
     }
 
@@ -109,7 +108,6 @@ public class CsarFilesystemDao implements CsarDao {
     public Csar find(String identifier) {
         readFromDisk(); // TODO: change this to some smart behaviour. e.g. file watcher
         return csarMap.get(identifier);
-
     }
 
     @Override
@@ -128,7 +126,6 @@ public class CsarFilesystemDao implements CsarDao {
         return new File(dataDir, csar.getIdentifier());
     }
 
-
     @Override
     public File getContentDir(Csar csar) {
         return new File(getRootDir(csar), CONTENT_DIR);
@@ -140,8 +137,7 @@ public class CsarFilesystemDao implements CsarDao {
     }
 
     /**
-     * Reads csars from disks
-     * post: csarMap reflects contents of DATA_DIR on disk
+     * Reads csars from disks post: csarMap reflects contents of DATA_DIR on disk
      */
     private void readFromDisk() {
         csarMap.clear();
@@ -156,12 +152,11 @@ public class CsarFilesystemDao implements CsarDao {
             }
         }
         logger.debug("in-memory csars in synced with file system");
-
     }
 
     /**
-     * Returns true if given file is a valid csar directory.
-     * Valid csar directories must contain 'transformations' and 'content' directory
+     * Returns true if given file is a valid csar directory. Valid csar directories must contain 'transformations' and
+     * 'content' directory
      */
     private boolean isCsarDir(File file) {
         if (file.isDirectory()) {

--- a/core/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
@@ -1,6 +1,8 @@
 package org.opentosca.toscana.core.csar;
 
 import org.apache.commons.io.FileUtils;
+import javax.annotation.PostConstruct;
+
 import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.TransformationDao;
 import org.opentosca.toscana.core.util.Preferences;
@@ -54,6 +56,12 @@ public class CsarFilesystemDao implements CsarDao {
 
         readFromDisk();
         this.transformationDao = transformationDao;
+    }
+
+    @PostConstruct
+    public void init() {
+        transformationDao.setCsarDao(this);
+        readFromDisk();
     }
 
     @Override

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/Transformation.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/Transformation.java
@@ -16,8 +16,6 @@ public interface Transformation {
 
     /**
      * Sets the state of the transformation, this is only temporary and will be removed later.
-     *
-     * @param state
      */
     void setState(TransformationState state);
 
@@ -27,9 +25,8 @@ public interface Transformation {
     Platform getPlatform();
 
     /**
-     * Sets the value of the property with its given key.
-     * Throws a IllegalArgumentException if a property with the given key cannot be found
-     * or if the entered value is invalid
+     * Sets the value of the property with its given key. Throws a IllegalArgumentException if a property with the given
+     * key cannot be found or if the entered value is invalid
      */
     default void setProperty(String key, String value) {
         getProperties().setPropertyValue(key, value);
@@ -55,14 +52,15 @@ public interface Transformation {
     Log getLog();
 
     /**
-     * If the transformation is finished, this will return a TargetArtifact
-     * object pointing to the generated target artifact otherwise it returns null!
+     * If the transformation is finished, this will return a TargetArtifact object pointing to the generated target
+     * artifact otherwise it returns null!
      */
     TargetArtifact getTargetArtifact();
+
+    void setTargetArtifact(TargetArtifact targetArtifact);
 
     /**
      * @return Returns the underlying Csar of the transformation
      */
     Csar getCsar();
-
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationDao.java
@@ -1,10 +1,11 @@
 package org.opentosca.toscana.core.transformation;
 
-import org.opentosca.toscana.core.csar.Csar;
-import org.opentosca.toscana.core.transformation.platform.Platform;
-
 import java.io.File;
 import java.util.List;
+
+import org.opentosca.toscana.core.csar.Csar;
+import org.opentosca.toscana.core.csar.CsarDao;
+import org.opentosca.toscana.core.transformation.platform.Platform;
 
 /**
  * Data Access Object for Transformation objects.
@@ -12,8 +13,8 @@ import java.util.List;
 public interface TransformationDao {
 
     /**
-     * Creates a new transformation for given csar and platform.
-     * If a transformation with this csar and platform already exists, also deletes the old transformation.
+     * Creates a new transformation for given csar and platform. If a transformation with this csar and platform already
+     * exists, also deletes the old transformation.
      *
      * @param csar     the csar on which the new transformation will be based on
      * @param platform the target platform of the new transformation
@@ -23,33 +24,23 @@ public interface TransformationDao {
 
     /**
      * Deletes given transformation
-     *
-     * @param transformation
      */
     void delete(Transformation transformation);
 
-
     /**
      * Returns all transformation objects which match given csar and plattform
-     *
-     * @param csar
-     * @param platform
-     * @return
      */
     Transformation find(Csar csar, Platform platform);
 
     /**
      * Returns all transformation objects which match given csar
-     *
-     * @param csar
-     * @return
      */
     List<Transformation> find(Csar csar);
 
     /**
-     * @param transformation
      * @return the root directory of given transformation
      */
     File getRootDir(Transformation transformation);
+
     void setCsarDao(CsarDao csarDao);
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationDao.java
@@ -51,4 +51,5 @@ public interface TransformationDao {
      * @return the root directory of given transformation
      */
     File getRootDir(Transformation transformation);
+    void setCsarDao(CsarDao csarDao);
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
@@ -1,21 +1,22 @@
 package org.opentosca.toscana.core.transformation;
 
-import org.apache.commons.io.FileUtils;
-import org.opentosca.toscana.core.csar.Csar;
-import org.opentosca.toscana.core.csar.CsarDao;
-import org.opentosca.toscana.core.transformation.platform.Platform;
-import org.opentosca.toscana.core.transformation.platform.PlatformService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.opentosca.toscana.core.csar.Csar;
+import org.opentosca.toscana.core.csar.CsarDao;
+import org.opentosca.toscana.core.transformation.platform.Platform;
+import org.opentosca.toscana.core.transformation.platform.PlatformService;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public class TransformationFilesystemDao implements TransformationDao {
@@ -38,7 +39,6 @@ public class TransformationFilesystemDao implements TransformationDao {
         return transformation;
     }
 
-
     @Override
     public void delete(Transformation transformation) {
         File transformationDir = getRootDir(transformation);
@@ -49,7 +49,6 @@ public class TransformationFilesystemDao implements TransformationDao {
         } catch (IOException e) {
             logger.error("failed to delete directory of transformation '{}'", transformation, e);
         }
-
     }
 
     @Override
@@ -86,7 +85,6 @@ public class TransformationFilesystemDao implements TransformationDao {
         } else {
             return null;
         }
-
     }
 
     @Override

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
@@ -25,8 +25,7 @@ public class TransformationFilesystemDao implements TransformationDao {
     private PlatformService platformService;
 
     @Autowired
-    public TransformationFilesystemDao(CsarDao csarDao, PlatformService platformService) {
-        this.csarDao = csarDao;
+    public TransformationFilesystemDao(PlatformService platformService) {
         this.platformService = platformService;
     }
 
@@ -95,4 +94,7 @@ public class TransformationFilesystemDao implements TransformationDao {
         return new File(csarDao.getTransformationsDir(transformation.getCsar()), transformation.getPlatform().id);
     }
 
+    public void setCsarDao(CsarDao csarDao) {
+        this.csarDao = csarDao;
+    }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
@@ -1,16 +1,17 @@
 package org.opentosca.toscana.core.transformation;
 
-import ch.qos.logback.classic.Logger;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.transformation.artifacts.TargetArtifact;
 import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyInstance;
-import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
+import ch.qos.logback.classic.Logger;
+import org.slf4j.LoggerFactory;
 
 class TransformationImpl implements Transformation {
 
@@ -71,11 +72,17 @@ class TransformationImpl implements Transformation {
     }
 
     /**
-     * @return if this transformation object's state is <code>DONE</code>, returns the target artifact of the transformation.
-     * Else returns null.
+     * @return if this transformation object's state is <code>DONE</code>, returns the target artifact of the
+     * transformation. Else returns null.
      */
+    @Override
     public TargetArtifact getTargetArtifact() {
         return targetArtifact;
+    }
+
+    @Override
+    public void setTargetArtifact(TargetArtifact artifact) {
+        this.targetArtifact = artifact;
     }
 
     @Override

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationServiceImpl.java
@@ -1,23 +1,24 @@
 package org.opentosca.toscana.core.transformation;
 
-import org.opentosca.toscana.core.csar.Csar;
-import org.opentosca.toscana.core.csar.CsarDao;
-import org.opentosca.toscana.core.plugin.PluginService;
-import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
-import org.opentosca.toscana.core.transformation.execution.ExecutionTask;
-import org.opentosca.toscana.core.transformation.platform.Platform;
-import org.opentosca.toscana.core.transformation.properties.RequirementType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.stereotype.Service;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import org.opentosca.toscana.core.csar.Csar;
+import org.opentosca.toscana.core.csar.CsarDao;
+import org.opentosca.toscana.core.plugin.PluginService;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
+import org.opentosca.toscana.core.transformation.execution.ExecutionTask;
+import org.opentosca.toscana.core.transformation.platform.Platform;
+import org.opentosca.toscana.core.transformation.properties.RequirementType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
 
 @Service
 public class TransformationServiceImpl implements TransformationService {
@@ -27,7 +28,7 @@ public class TransformationServiceImpl implements TransformationService {
     private final TransformationDao transformationDao;
     private final CsarDao csarDao;
     private final PluginService pluginService;
-    private final ArtifactManagementService artifactManagementService;
+    private final ArtifactService artifactService;
 
     private Map<Transformation, Future<?>> tasks = new HashMap<>();
     private ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -37,12 +38,12 @@ public class TransformationServiceImpl implements TransformationService {
         TransformationDao transformationDao,
         PluginService pluginService,
         @Lazy CsarDao csarDao,
-        ArtifactManagementService artifactManagementService
+        ArtifactService artifactService
     ) {
         this.transformationDao = transformationDao;
         this.pluginService = pluginService;
         this.csarDao = csarDao;
-        this.artifactManagementService = artifactManagementService;
+        this.artifactService = artifactService;
     }
 
     @Override
@@ -60,7 +61,7 @@ public class TransformationServiceImpl implements TransformationService {
             Future<?> taskFuture = executor.submit(
                 new ExecutionTask(
                     transformation,
-                    artifactManagementService,
+                    artifactService,
                     pluginService,
                     csarDao.getContentDir(transformation.getCsar()),
                     transformationDao.getRootDir(transformation)
@@ -95,5 +96,4 @@ public class TransformationServiceImpl implements TransformationService {
         tasks.remove(transformation);
         return true;
     }
-
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementService.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementService.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.core.transformation.artifacts;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.opentosca.toscana.core.transformation.Transformation;
@@ -14,4 +15,9 @@ public interface ArtifactManagementService {
      * serve its URL to the client.
      */
     String serveArtifact(Transformation transformation) throws IOException;
+
+    /**
+     * @return the general target artifact dir
+     */
+    File getArtifactDir();
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementService.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementService.java
@@ -1,18 +1,17 @@
 package org.opentosca.toscana.core.transformation.artifacts;
 
-import java.io.File;
 import java.io.IOException;
 
+import org.opentosca.toscana.core.transformation.Transformation;
+
 /**
- * This interface describes a service that will tell spring to serve a file or multiple as a static resource
+ * Service that will tell spring to serve a file or multiple as a static resource
  */
 public interface ArtifactManagementService {
+
     /**
-     * This method takes the target artifact of the transformation and copies it to the "resource directory" to allow
-     * Spring to send a URL to the client.
-     *
-     * @param transformation
-     * @return
+     * Takes the target artifact of the transformation and copies it to the "resource directory" to allow Spring to
+     * serve its URL to the client.
      */
-    String saveToArtifactDirectory(File transformationDir, String csarName, String platformName) throws IOException;
+    String serveArtifact(Transformation transformation) throws IOException;
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementService.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementService.java
@@ -14,7 +14,7 @@ public interface ArtifactManagementService {
      * Takes the target artifact of the transformation and copies it to the "resource directory" to allow Spring to
      * serve its URL to the client.
      */
-    String serveArtifact(Transformation transformation) throws IOException;
+    TargetArtifact serveArtifact(Transformation transformation) throws IOException;
 
     /**
      * @return the general target artifact dir

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
@@ -22,28 +22,31 @@ import static java.lang.System.currentTimeMillis;
 public class ArtifactManagementServiceImpl
     implements ArtifactManagementService {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
-    private final Preferences preferences;
+    private final static String ARTIFACT_DIR = "artifacts";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final TransformationDao transformatioDao;
     private final SimpleDateFormat format = new SimpleDateFormat("dd-MM-yy_hh-mm");
+    private final File artifactDir;
 
     @Autowired
     public ArtifactManagementServiceImpl(Preferences preferences, TransformationDao transformationDao) {
-        this.preferences = preferences;
         this.transformatioDao = transformationDao;
+        artifactDir = new File(preferences.getDataDir(), ARTIFACT_DIR);
+        logger.info("Artifact directory is {}", artifactDir.getAbsolutePath());
     }
 
     @Override
     public String serveArtifact(Transformation transformation) throws IOException {
-        String csarName = transformation.getCsar().getIdentifier();
-        String platformName = transformation.getPlatform().id;
+        String csarId = transformation.getCsar().getIdentifier();
+        String platformId = transformation.getPlatform().id;
         File transformationWorkingDirectory = transformatioDao.getRootDir(transformation);
         //TODO Determine better name for artifacts
-        String filename = csarName + "-" + platformName + "_" + format.format(new Date(currentTimeMillis())) + ".zip";
-        File outputFile = new File(preferences.getArtifactDir(), filename);
+        String filename = csarId + "-" + platformId + "_" + format.format(new Date(currentTimeMillis())) + ".zip";
+        File outputFile = new File(artifactDir, filename);
 
         FileOutputStream out = new FileOutputStream(outputFile);
-        log.info("Writing artifact data to {}", outputFile.getAbsolutePath());
+        logger.info("Writing artifact data to {}", outputFile.getAbsolutePath());
         ZipUtility.compressDirectory(transformationWorkingDirectory, out);
         out.close();
 

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
@@ -33,6 +33,7 @@ public class ArtifactManagementServiceImpl
     public ArtifactManagementServiceImpl(Preferences preferences, TransformationDao transformationDao) {
         this.transformatioDao = transformationDao;
         artifactDir = new File(preferences.getDataDir(), ARTIFACT_DIR);
+        artifactDir.mkdir();
         logger.info("Artifact directory is {}", artifactDir.getAbsolutePath());
     }
 
@@ -51,5 +52,10 @@ public class ArtifactManagementServiceImpl
         out.close();
 
         return "/artifacts/" + filename;
+    }
+
+    @Override
+    public File getArtifactDir() {
+        return artifactDir;
     }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
@@ -38,7 +38,7 @@ public class ArtifactManagementServiceImpl
     }
 
     @Override
-    public String serveArtifact(Transformation transformation) throws IOException {
+    public TargetArtifact serveArtifact(Transformation transformation) throws IOException {
         String csarId = transformation.getCsar().getIdentifier();
         String platformId = transformation.getPlatform().id;
         File transformationWorkingDirectory = transformatioDao.getRootDir(transformation);
@@ -51,7 +51,7 @@ public class ArtifactManagementServiceImpl
         ZipUtility.compressDirectory(transformationWorkingDirectory, out);
         out.close();
 
-        return "/artifacts/" + filename;
+        return new TargetArtifact("/artifacts/" + filename);
     }
 
     @Override

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
@@ -1,17 +1,20 @@
 package org.opentosca.toscana.core.transformation.artifacts;
 
-import org.opentosca.toscana.core.util.Preferences;
-import org.opentosca.toscana.core.util.ZipUtility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+
+import org.opentosca.toscana.core.transformation.Transformation;
+import org.opentosca.toscana.core.transformation.TransformationDao;
+import org.opentosca.toscana.core.util.Preferences;
+import org.opentosca.toscana.core.util.ZipUtility;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import static java.lang.System.currentTimeMillis;
 
@@ -21,22 +24,26 @@ public class ArtifactManagementServiceImpl
 
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final Preferences preferences;
+    private final TransformationDao transformatioDao;
     private final SimpleDateFormat format = new SimpleDateFormat("dd-MM-yy_hh-mm");
 
     @Autowired
-    public ArtifactManagementServiceImpl(Preferences preferences) {
+    public ArtifactManagementServiceImpl(Preferences preferences, TransformationDao transformationDao) {
         this.preferences = preferences;
+        this.transformatioDao = transformationDao;
     }
 
     @Override
-    public String saveToArtifactDirectory(File transformationWorkingDirectory, String csarName, String platformName)
-        throws IOException {
+    public String serveArtifact(Transformation transformation) throws IOException {
+        String csarName = transformation.getCsar().getIdentifier();
+        String platformName = transformation.getPlatform().id;
+        File transformationWorkingDirectory = transformatioDao.getRootDir(transformation);
         //TODO Determine better name for artifacts
         String filename = csarName + "-" + platformName + "_" + format.format(new Date(currentTimeMillis())) + ".zip";
         File outputFile = new File(preferences.getArtifactDir(), filename);
 
         FileOutputStream out = new FileOutputStream(outputFile);
-        log.info("Writing artifact data to {}",outputFile.getAbsolutePath());
+        log.info("Writing artifact data to {}", outputFile.getAbsolutePath());
         ZipUtility.compressDirectory(transformationWorkingDirectory, out);
         out.close();
 

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactManagementServiceImpl.java
@@ -16,7 +16,7 @@ import java.util.Date;
 import static java.lang.System.currentTimeMillis;
 
 @Service
-public class ResourceManager
+public class ArtifactManagementServiceImpl
     implements ArtifactManagementService {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -24,7 +24,7 @@ public class ResourceManager
     private final SimpleDateFormat format = new SimpleDateFormat("dd-MM-yy_hh-mm");
 
     @Autowired
-    public ResourceManager(Preferences preferences) {
+    public ArtifactManagementServiceImpl(Preferences preferences) {
         this.preferences = preferences;
     }
 
@@ -36,6 +36,7 @@ public class ResourceManager
         File outputFile = new File(preferences.getArtifactDir(), filename);
 
         FileOutputStream out = new FileOutputStream(outputFile);
+        log.info("Writing artifact data to {}",outputFile.getAbsolutePath());
         ZipUtility.compressDirectory(transformationWorkingDirectory, out);
         out.close();
 

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactService.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactService.java
@@ -11,8 +11,8 @@ import org.opentosca.toscana.core.transformation.Transformation;
 public interface ArtifactService {
 
     /**
-     * Takes the target artifact of the transformation and copies it to the "resource directory" to allow Spring to
-     * serve its URL to the client.
+     * Takes the target artifact of given transformation and copies it to the "resource directory" in order to allow
+     * Spring to serve its URL to the client.
      */
     TargetArtifact serveArtifact(Transformation transformation) throws IOException;
 

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactService.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactService.java
@@ -8,7 +8,7 @@ import org.opentosca.toscana.core.transformation.Transformation;
 /**
  * Service that will tell spring to serve a file or multiple as a static resource
  */
-public interface ArtifactManagementService {
+public interface ArtifactService {
 
     /**
      * Takes the target artifact of the transformation and copies it to the "resource directory" to allow Spring to

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactServiceImpl.java
@@ -42,7 +42,6 @@ public class ArtifactServiceImpl
         String csarId = transformation.getCsar().getIdentifier();
         String platformId = transformation.getPlatform().id;
         File transformationWorkingDirectory = transformatioDao.getRootDir(transformation);
-        //TODO Determine better name for artifacts
         String filename = csarId + "-" + platformId + "_" + format.format(new Date(currentTimeMillis())) + ".zip";
         File outputFile = new File(artifactDir, filename);
 

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactServiceImpl.java
@@ -19,8 +19,8 @@ import org.springframework.stereotype.Service;
 import static java.lang.System.currentTimeMillis;
 
 @Service
-public class ArtifactManagementServiceImpl
-    implements ArtifactManagementService {
+public class ArtifactServiceImpl
+    implements ArtifactService {
 
     private final static String ARTIFACT_DIR = "artifacts";
 
@@ -30,7 +30,7 @@ public class ArtifactManagementServiceImpl
     private final File artifactDir;
 
     @Autowired
-    public ArtifactManagementServiceImpl(Preferences preferences, TransformationDao transformationDao) {
+    public ArtifactServiceImpl(Preferences preferences, TransformationDao transformationDao) {
         this.transformatioDao = transformationDao;
         artifactDir = new File(preferences.getDataDir(), ARTIFACT_DIR);
         artifactDir.mkdir();

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/ArtifactServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.Date;
 
 import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.TransformationDao;
+import org.opentosca.toscana.core.transformation.TransformationState;
 import org.opentosca.toscana.core.util.Preferences;
 import org.opentosca.toscana.core.util.ZipUtility;
 
@@ -42,7 +43,8 @@ public class ArtifactServiceImpl
         String csarId = transformation.getCsar().getIdentifier();
         String platformId = transformation.getPlatform().id;
         File transformationWorkingDirectory = transformatioDao.getRootDir(transformation);
-        String filename = csarId + "-" + platformId + "_" + format.format(new Date(currentTimeMillis())) + ".zip";
+        String failed = transformation.getState() == TransformationState.ERROR ? "_failed" : "";
+        String filename = csarId + "-" + platformId + "_" + format.format(new Date(currentTimeMillis())) + failed + ".zip";
         File outputFile = new File(artifactDir, filename);
 
         FileOutputStream out = new FileOutputStream(outputFile);

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/TargetArtifact.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/TargetArtifact.java
@@ -1,8 +1,21 @@
 package org.opentosca.toscana.core.transformation.artifacts;
 
 public class TargetArtifact {
-    // TODO
+
+    private String relativeDlUrl = "";
+
+    public TargetArtifact() {
+    }
+
+    public TargetArtifact(String relativeDlUrl) {
+        this.relativeDlUrl = relativeDlUrl;
+    }
+
     public String getArtifactDownloadURL() {
-        return "http://not-yet-implemented.com/";
+        return relativeDlUrl;
+    }
+
+    public void setArtifactDownloadURL(String url) {
+        this.relativeDlUrl = url;
     }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/TargetArtifact.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/artifacts/TargetArtifact.java
@@ -2,20 +2,16 @@ package org.opentosca.toscana.core.transformation.artifacts;
 
 public class TargetArtifact {
 
-    private String relativeDlUrl = "";
+    private final String relativePath;
 
-    public TargetArtifact() {
-    }
-
-    public TargetArtifact(String relativeDlUrl) {
-        this.relativeDlUrl = relativeDlUrl;
+    /**
+     * @param relativePath relative path to the target artifact
+     */
+    public TargetArtifact(String relativePath) {
+        this.relativePath = relativePath;
     }
 
     public String getArtifactDownloadURL() {
-        return relativeDlUrl;
-    }
-
-    public void setArtifactDownloadURL(String url) {
-        this.relativeDlUrl = url;
+        return relativePath;
     }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
@@ -7,7 +7,7 @@ import org.opentosca.toscana.core.plugin.TransformationPlugin;
 import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.TransformationContext;
 import org.opentosca.toscana.core.transformation.TransformationState;
-import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
 import org.opentosca.toscana.core.transformation.artifacts.TargetArtifact;
 
 import org.slf4j.Logger;
@@ -18,13 +18,13 @@ public class ExecutionTask implements Runnable {
     private final TransformationPlugin plugin;
     private final File csarContentDir;
     private final File transformationRootDir;
-    private ArtifactManagementService ams;
+    private ArtifactService ams;
 
     private Logger log;
 
     public ExecutionTask(
         Transformation transformation,
-        ArtifactManagementService ams,
+        ArtifactService ams,
         PluginService pluginService,
         File csarContentDir,
         File transformationRootDir

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.TransformationContext;
 import org.opentosca.toscana.core.transformation.TransformationState;
 import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+import org.opentosca.toscana.core.transformation.artifacts.TargetArtifact;
 
 import org.slf4j.Logger;
 
@@ -50,10 +51,9 @@ public class ExecutionTask implements Runnable {
 
             log.info("Compressing target artifacts");
             if (transformationRootDir != null && transformationRootDir.listFiles().length != 0) {
-                String path = ams.serveArtifact(transformation);
-                log.info("Artifact is can be downloaded at relative url {}", path);
-                //TODO Fix TargetArtifact not existing
-                //transformation.getTargetArtifact().setArtifactDownloadURL(path);
+                TargetArtifact artifact = ams.serveArtifact(transformation);
+                log.info("Artifact is can be downloaded at relative url {}", artifact.getArtifactDownloadURL());
+                transformation.setTargetArtifact(artifact);
             } else {
                 log.info("Failed to compress target artifacts: Transformation generated no output files");
             }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
@@ -1,14 +1,15 @@
 package org.opentosca.toscana.core.transformation.execution;
 
+import java.io.File;
+
 import org.opentosca.toscana.core.plugin.PluginService;
 import org.opentosca.toscana.core.plugin.TransformationPlugin;
 import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.TransformationContext;
 import org.opentosca.toscana.core.transformation.TransformationState;
 import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
-import org.slf4j.Logger;
 
-import java.io.File;
+import org.slf4j.Logger;
 
 public class ExecutionTask implements Runnable {
 
@@ -44,21 +45,17 @@ public class ExecutionTask implements Runnable {
         try {
             log.debug("Creating transformation root directory {}", transformationRootDir.getAbsolutePath());
             transformationRootDir.mkdirs();
-            
+
             plugin.transform(new TransformationContext(transformation, csarContentDir, transformationRootDir));
 
             log.info("Compressing target artifacts");
             if (transformationRootDir != null && transformationRootDir.listFiles().length != 0) {
-                String path = ams.saveToArtifactDirectory(
-                    transformationRootDir,
-                    transformation.getCsar().getIdentifier(),
-                    transformation.getPlatform().id
-                );
+                String path = ams.serveArtifact(transformation);
                 log.info("Artifact is can be downloaded at relative url {}", path);
                 //TODO Fix TargetArtifact not existing
                 //transformation.getTargetArtifact().setArtifactDownloadURL(path);
             } else {
-                log.info("No The transformation did not create any target artifacts");
+                log.info("Failed to compress target artifacts: Transformation generated no output files");
             }
         } catch (Exception e) {
             log.error("Transforming of {}/{} has errored!",

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
@@ -59,7 +59,7 @@ public class ExecutionTask implements Runnable {
                 transformation.setTargetArtifact(artifact);
                 log.info("Artifact archive is served at relative url {}", artifact.getArtifactDownloadURL());
             } catch (IOException e) {
-                log.error("Failed to servce artifact archive for transformation {}/{}", csarId, platformId, e);
+                log.error("Failed to serve artifact archive for transformation {}/{}", csarId, platformId, e);
             }
         } else {
             transformation.setState(TransformationState.ERROR);

--- a/core/src/main/java/org/opentosca/toscana/core/util/FileUtils.java
+++ b/core/src/main/java/org/opentosca/toscana/core/util/FileUtils.java
@@ -1,4 +1,4 @@
-package org.opentosca.toscana.core.testutils;
+package org.opentosca.toscana.core.util;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +10,11 @@ public class FileUtils {
     private static final Logger log = LoggerFactory.getLogger(FileUtils.class);
 
     public static void delete(File f) {
-        log.info("Deleting {}", f.getAbsolutePath());
+        delete(f, log);
+    }
+
+    public static void delete(File f, Logger log) {
+        log.debug("Deleting {}", f.getAbsolutePath());
         if (f.isFile()) {
             f.delete();
         } else if (f.isDirectory()) {

--- a/core/src/main/java/org/opentosca/toscana/core/util/Preferences.java
+++ b/core/src/main/java/org/opentosca/toscana/core/util/Preferences.java
@@ -1,17 +1,18 @@
 package org.opentosca.toscana.core.util;
 
+import java.io.File;
+
+import javax.annotation.PostConstruct;
+
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
-import java.io.File;
-
 /**
- * Manages all preferences.
- * Uses Spring Properties (therefore looks in property files, java flags and system environment for values)
+ * Manages all preferences. Uses Spring Properties (therefore looks in property files, java flags and system environment
+ * for values)
  */
 @Service
 public class Preferences {
@@ -24,7 +25,6 @@ public class Preferences {
     private String dataPathFallbackNix;
 
     private File dataDir;
-    private File artifactDir;
 
     private static final Logger logger = LoggerFactory.getLogger(Preferences.class.getName());
 
@@ -43,11 +43,8 @@ public class Preferences {
         }
         logger.info("datadir is '{}'", dataPath);
         dataDir = new File(dataPath);
-        artifactDir = new File(dataDir, "artifacts");
         dataDir.mkdirs();
-        artifactDir.mkdirs();
         logger.info("Data directory is {}", dataDir.getAbsolutePath());
-        logger.info("Artifact directory is {}", artifactDir.getAbsolutePath());
         if (!dataDir.exists()) {
             logger.error("Failed to create data directory");
         }
@@ -55,9 +52,5 @@ public class Preferences {
 
     public File getDataDir() {
         return dataDir;
-    }
-
-    public File getArtifactDir() {
-        return artifactDir;
     }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/util/ZipUtility.java
+++ b/core/src/main/java/org/opentosca/toscana/core/util/ZipUtility.java
@@ -1,14 +1,18 @@
 package org.opentosca.toscana.core.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ZipUtility {
 
@@ -19,12 +23,11 @@ public class ZipUtility {
     private static final int BUFFER_SIZE = 4096;
 
     /**
-     * Extracts a ZipInputStream specified by the zipIn to a directory specified by
-     * destDirectory (will be created if does not exists)
+     * Extracts a ZipInputStream specified by the zipIn to a directory specified by destDirectory (will be created if
+     * does not exists)
      *
      * @param zipIn         ZipInputStream of zip archive
      * @param destDirectory target directory for unzipping
-     * @throws IOException
      */
     public static void unzip(ZipInputStream zipIn, String destDirectory) throws IOException {
         File destDir = new File(destDirectory);
@@ -49,10 +52,6 @@ public class ZipUtility {
 
     /**
      * Extracts a zip entry (file entry)
-     *
-     * @param zipIn
-     * @param filePath
-     * @throws IOException
      */
     private static void extractFile(ZipInputStream zipIn, String filePath) throws IOException {
         logger.debug("Extracting file: {}", filePath);
@@ -72,12 +71,7 @@ public class ZipUtility {
     }
 
     /**
-     * Reads a given directory (and all its subdirectories) and createss a compressed version thats written to the given
-     * output stream
-     *
-     * @param directory
-     * @param output
-     * @throws IOException
+     * Compresses given directory recursively to given output stream
      */
     public static void compressDirectory(File directory, OutputStream output) throws IOException {
         logger.debug("Compressing Directory {}", directory.getAbsolutePath());
@@ -121,5 +115,4 @@ public class ZipUtility {
         //close zip output
         zipOut.close();
     }
-
 }

--- a/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
+++ b/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
@@ -16,8 +16,8 @@ import org.opentosca.toscana.core.transformation.TransformationDao;
 import org.opentosca.toscana.core.transformation.TransformationFilesystemDao;
 import org.opentosca.toscana.core.transformation.TransformationService;
 import org.opentosca.toscana.core.transformation.TransformationServiceImpl;
-import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
-import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementServiceImpl;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactServiceImpl;
 import org.opentosca.toscana.core.transformation.platform.PlatformService;
 import org.opentosca.toscana.core.util.FileSystem;
 import org.opentosca.toscana.core.util.Preferences;
@@ -38,8 +38,8 @@ import org.springframework.context.annotation.PropertySource;
 public class TestCoreConfiguration extends CoreConfiguration {
 
     @Bean
-    public ArtifactManagementService artifactManagementService(Preferences preferences, TransformationDao transformationDao) {
-        return new ArtifactManagementServiceImpl(preferences, transformationDao);
+    public ArtifactService artifactManagementService(Preferences preferences, TransformationDao transformationDao) {
+        return new ArtifactServiceImpl(preferences, transformationDao);
     }
 
     @Bean
@@ -105,7 +105,7 @@ public class TestCoreConfiguration extends CoreConfiguration {
         TransformationDao repo,
         @Lazy CsarDao csarDao,
         PluginService service,
-        ArtifactManagementService ams
+        ArtifactService ams
     ) {
         TransformationServiceImpl bean = new TransformationServiceImpl(repo, service, csarDao, ams);
         return bean;

--- a/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
+++ b/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
@@ -1,5 +1,7 @@
 package org.opentosca.toscana.core;
 
+import java.util.Arrays;
+
 import org.opentosca.toscana.core.csar.CsarDao;
 import org.opentosca.toscana.core.csar.CsarFilesystemDao;
 import org.opentosca.toscana.core.csar.CsarService;
@@ -22,20 +24,24 @@ import org.opentosca.toscana.core.util.Preferences;
 import org.opentosca.toscana.plugins.awscf.CloudFormationPlugin;
 import org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryPlugin;
 import org.opentosca.toscana.plugins.kubernetes.KubernetesPlugin;
-import org.springframework.context.annotation.*;
 
-import java.util.Arrays;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource("classpath:application.yml")
 @Profile("!controller_test")
 public class TestCoreConfiguration extends CoreConfiguration {
-    
+
     @Bean
-    public ArtifactManagementService artifactManagementService(Preferences preferences) {
-        return new ArtifactManagementServiceImpl(preferences);
+    public ArtifactManagementService artifactManagementService(Preferences preferences, TransformationDao transformationDao) {
+        return new ArtifactManagementServiceImpl(preferences, transformationDao);
     }
-    
+
     @Bean
     public CsarDao csarDao(Preferences preferences, @Lazy TransformationDao transformationDao) {
         return new CsarFilesystemDao(preferences, transformationDao);
@@ -55,7 +61,6 @@ public class TestCoreConfiguration extends CoreConfiguration {
         TestCsars bean = new TestCsars(dao);
         return bean;
     }
-
 
     //TODO Replace with filesystem implementation
     @Bean
@@ -105,5 +110,4 @@ public class TestCoreConfiguration extends CoreConfiguration {
         TransformationServiceImpl bean = new TransformationServiceImpl(repo, service, csarDao, ams);
         return bean;
     }
-
 }

--- a/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
+++ b/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
@@ -14,6 +14,8 @@ import org.opentosca.toscana.core.transformation.TransformationDao;
 import org.opentosca.toscana.core.transformation.TransformationFilesystemDao;
 import org.opentosca.toscana.core.transformation.TransformationService;
 import org.opentosca.toscana.core.transformation.TransformationServiceImpl;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementServiceImpl;
 import org.opentosca.toscana.core.transformation.platform.PlatformService;
 import org.opentosca.toscana.core.util.FileSystem;
 import org.opentosca.toscana.core.util.Preferences;
@@ -28,6 +30,12 @@ import java.util.Arrays;
 @PropertySource("classpath:application.yml")
 @Profile("!controller_test")
 public class TestCoreConfiguration extends CoreConfiguration {
+    
+    @Bean
+    public ArtifactManagementService artifactManagementService(Preferences preferences) {
+        return new ArtifactManagementServiceImpl(preferences);
+    }
+    
     @Bean
     public CsarDao csarDao(Preferences preferences, @Lazy TransformationDao transformationDao) {
         return new CsarFilesystemDao(preferences, transformationDao);
@@ -88,8 +96,13 @@ public class TestCoreConfiguration extends CoreConfiguration {
     }
 
     @Bean
-    public TransformationService transformationService(TransformationDao repo, PluginService service) {
-        TransformationServiceImpl bean = new TransformationServiceImpl(repo, service);
+    public TransformationService transformationService(
+        TransformationDao repo,
+        @Lazy CsarDao csarDao,
+        PluginService service,
+        ArtifactManagementService ams
+    ) {
+        TransformationServiceImpl bean = new TransformationServiceImpl(repo, service, csarDao, ams);
         return bean;
     }
 

--- a/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
+++ b/core/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
@@ -95,8 +95,8 @@ public class TestCoreConfiguration extends CoreConfiguration {
 
     @Bean
     @Primary
-    public TransformationDao transformationDao(PlatformService platforms, @Lazy CsarDao repo) {
-        TransformationFilesystemDao bean = new TransformationFilesystemDao(repo, platforms);
+    public TransformationDao transformationDao(PlatformService platforms) {
+        TransformationFilesystemDao bean = new TransformationFilesystemDao(platforms);
         return bean;
     }
 

--- a/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
@@ -1,5 +1,14 @@
 package org.opentosca.toscana.core.api;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.security.MessageDigest;
+import java.util.Random;
+
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+import org.opentosca.toscana.core.util.FileUtils;
+import org.opentosca.toscana.core.util.Preferences;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.After;
@@ -7,8 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.opentosca.toscana.core.util.FileUtils;
-import org.opentosca.toscana.core.util.Preferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.annotation.DirtiesContext;
@@ -17,12 +24,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.security.MessageDigest;
-import java.util.Random;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -78,11 +82,11 @@ public class ArtifactControllerTest {
         }
 
         //Mocking preferences
-        preferences = Mockito.mock(Preferences.class);
-        when(preferences.getArtifactDir()).thenReturn(testdir);
+        ArtifactManagementService ams = Mockito.mock(ArtifactManagementService.class);
+        when(ams.getArtifactDir()).thenReturn(testdir);
 
         //initalizing controller
-        this.controller = new ArtifactController(preferences);
+        this.controller = new ArtifactController(ams);
         this.controller.enableArtifactList = true;
 
         //Building MockMvc

--- a/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.opentosca.toscana.core.testutils.FileUtils;
+import org.opentosca.toscana.core.util.FileUtils;
 import org.opentosca.toscana.core.util.Preferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
@@ -5,7 +5,7 @@ import java.io.FileOutputStream;
 import java.security.MessageDigest;
 import java.util.Random;
 
-import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
 import org.opentosca.toscana.core.util.FileUtils;
 import org.opentosca.toscana.core.util.Preferences;
 
@@ -82,7 +82,7 @@ public class ArtifactControllerTest {
         }
 
         //Mocking preferences
-        ArtifactManagementService ams = Mockito.mock(ArtifactManagementService.class);
+        ArtifactService ams = Mockito.mock(ArtifactService.class);
         when(ams.getArtifactDir()).thenReturn(testdir);
 
         //initalizing controller

--- a/core/src/test/java/org/opentosca/toscana/core/api/upload/UploadTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/upload/UploadTest.java
@@ -19,7 +19,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.fail;
-import static org.opentosca.toscana.core.testutils.FileUtils.delete;
+import static org.opentosca.toscana.core.util.FileUtils.delete;
 
 @RunWith(CICheckingJUnitRunner.class)
 public class UploadTest {

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/DummyTransformation.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/DummyTransformation.java
@@ -42,6 +42,7 @@ public class DummyTransformation implements Transformation {
         properties.setPropertyValue(key, value);
     }
 
+    @Override
     public void setState(TransformationState state) {
         this.state = state;
     }
@@ -58,9 +59,13 @@ public class DummyTransformation implements Transformation {
 
     @Override
     public TargetArtifact getTargetArtifact() {
-        return returnTargetArtifact ? new TargetArtifact() : null;
+        return returnTargetArtifact ? new TargetArtifact("some/path") : null;
     }
 
+    @Override
+    public void setTargetArtifact(TargetArtifact targetArtifact) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public Csar getCsar() {

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/ExecutionDummyPlugin.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/ExecutionDummyPlugin.java
@@ -1,11 +1,14 @@
 package org.opentosca.toscana.core.dummy;
 
+import java.io.InputStream;
+import java.util.HashSet;
+
 import org.opentosca.toscana.core.plugin.AbstractPlugin;
 import org.opentosca.toscana.core.transformation.TransformationContext;
 import org.opentosca.toscana.core.transformation.properties.Property;
-import org.slf4j.Logger;
 
-import java.util.HashSet;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
 
 public class ExecutionDummyPlugin extends AbstractPlugin {
 
@@ -36,6 +39,8 @@ public class ExecutionDummyPlugin extends AbstractPlugin {
     public void transform(TransformationContext transformation) throws Exception {
         Logger logger = transformation.getLogger(getClass());
         int i = 0;
+        InputStream stream = IOUtils.toInputStream("some transformation result");
+        transformation.getPluginFileAccess().write("some-output-file", stream);
         logger.info("Waiting 1s until completion");
         while (!Thread.currentThread().isInterrupted() && i < 100) {
             Thread.sleep(10);

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/FileCreatingExceutionDummyPlugin.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/FileCreatingExceutionDummyPlugin.java
@@ -1,0 +1,36 @@
+package org.opentosca.toscana.core.dummy;
+
+import org.opentosca.toscana.core.transformation.TransformationContext;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Random;
+
+public class FileCreatingExceutionDummyPlugin extends ExecutionDummyPlugin {
+    public FileCreatingExceutionDummyPlugin(String name, boolean failDuringExec) {
+        super(name, failDuringExec);
+    }
+
+    @Override
+    public void transform(TransformationContext transformation) throws Exception {
+        Random rnd = new Random(123456);
+        for (int i = 0; i < 5; i++) {
+            String outerPath = "outer-" + i;
+            for (int j = 0; j < 5; j++) {
+                String innerPath = "inner-" + i;
+                String path = outerPath + "/" + innerPath + ".bin";
+                writeFilepath(transformation, rnd, path);
+            }
+        }
+        for (int l = 0; l < 20; l++) {
+            writeFilepath(transformation, rnd, "file-" + l + ".bin");
+        }
+        super.transform(transformation);
+    }
+
+    public void writeFilepath(TransformationContext transformation, Random rnd, String path) throws IOException {
+        byte[] data = new byte[1024 * 100];
+        rnd.nextBytes(data);
+        transformation.getPluginFileAccess().write(path, new ByteArrayInputStream(data));
+    }
+}

--- a/core/src/test/java/org/opentosca/toscana/core/testdata/TestPlugins.java
+++ b/core/src/test/java/org/opentosca/toscana/core/testdata/TestPlugins.java
@@ -3,6 +3,7 @@ package org.opentosca.toscana.core.testdata;
 import org.assertj.core.util.Lists;
 import org.opentosca.toscana.core.dummy.DummyPlugin;
 import org.opentosca.toscana.core.dummy.ExecutionDummyPlugin;
+import org.opentosca.toscana.core.dummy.FileCreatingExceutionDummyPlugin;
 import org.opentosca.toscana.core.plugin.TransformationPlugin;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 
@@ -21,11 +22,23 @@ public class TestPlugins {
     public static final TransformationPlugin PLUGIN3 = new DummyPlugin(PLATFORM3);
     public static final TransformationPlugin PLUGIN4 = new DummyPlugin(PLATFORM4);
 
-    public static final ExecutionDummyPlugin PASSING_DUMMY = new ExecutionDummyPlugin("passing", false);
-    public static final ExecutionDummyPlugin FAILING_DUMMY = new ExecutionDummyPlugin("failing", true);
+    public static final ExecutionDummyPlugin PASSING_DUMMY =
+        new ExecutionDummyPlugin("passing", false);
+    public static final ExecutionDummyPlugin FAILING_DUMMY =
+        new ExecutionDummyPlugin("failing", true);
+
+    public static final ExecutionDummyPlugin PASSING_WRITING_DUMMY =
+        new FileCreatingExceutionDummyPlugin("passing-fw", false);
+    public static final ExecutionDummyPlugin FAILING_WRITING_DUMMY =
+        new FileCreatingExceutionDummyPlugin("failing-fw", true);
 
     public static final List<Platform> PLATFORMS = Lists.newArrayList(PLATFORM1, PLATFORM2, PLATFORM3, PLATFORM4);
-    public static final List<TransformationPlugin> PLUGINS = Lists.newArrayList(PLUGIN1, PLUGIN2, PLUGIN3, PLUGIN4, PASSING_DUMMY, FAILING_DUMMY);
+    public static final List<TransformationPlugin> PLUGINS = Lists.newArrayList(
+        PLUGIN1, PLUGIN2,
+        PLUGIN3, PLUGIN4,
+        PASSING_DUMMY, FAILING_DUMMY,
+        PASSING_WRITING_DUMMY, FAILING_WRITING_DUMMY
+    );
 
     /**
      * In given csarTransformationsDir, creates for every given target platform a fake transformation on disk

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
@@ -103,10 +103,10 @@ public class TransformationServiceImplTest extends BaseSpringTest {
 
     @Test
     public void startTransformationWithArtifacts() throws Exception {
-        startTransfomationInternal(TransformationState.DONE, passingDummyFw.getPlatformDetails());
+        Transformation transformation = startTransfomationInternal(TransformationState.DONE, passingDummyFw.getPlatformDetails());
         String id = passingDummyFw.getIdentifier();
 
-        lookForArtifactArchive(id);
+        lookForArtifactArchive(transformation);
     }
 
     @Test
@@ -152,14 +152,15 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         assertFalse(csar.getTransformations().containsValue(transformation));
     }
 
-    private void startTransfomationInternal(TransformationState expectedState, Platform platform) throws InterruptedException {
-        DummyCsar csar = new DummyCsar("test");
+    private Transformation startTransfomationInternal(TransformationState expectedState, Platform platform) throws InterruptedException, FileNotFoundException {
+        Csar csar = testCsars.getCsar(TestCsars.CSAR_YAML_VALID_SIMPLETASK);
         service.createTransformation(csar, platform);
         Transformation t = csar.getTransformations().get(platform.id);
         assertTrue(service.startTransformation(t));
         Thread.sleep(100);
         waitForTransformationStateChange(t);
         assertEquals(expectedState, t.getState());
+        return t;
     }
 
     private void waitForTransformationStateChange(Transformation t) throws InterruptedException {
@@ -168,8 +169,8 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         }
     }
 
-    public void lookForArtifactArchive(String id) {
-        String filename = "test-" + id + "_";
+    public void lookForArtifactArchive(Transformation transformation) {
+        String filename = transformation.getCsar().getIdentifier() + "-" + transformation.getPlatform().id + "_";
         boolean found = false;
         for (File file : ams.getArtifactDir().listFiles()) {
             if (file.getName().startsWith(filename)) {

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
@@ -1,24 +1,26 @@
 package org.opentosca.toscana.core.transformation;
 
-import org.junit.Before;
-import org.junit.Test;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashSet;
+
 import org.opentosca.toscana.core.BaseSpringTest;
 import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.dummy.DummyCsar;
 import org.opentosca.toscana.core.dummy.ExecutionDummyPlugin;
 import org.opentosca.toscana.core.testdata.TestCsars;
 import org.opentosca.toscana.core.testdata.TestPlugins;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyType;
 import org.opentosca.toscana.core.transformation.properties.RequirementType;
-import org.opentosca.toscana.core.util.Preferences;
+
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.util.HashSet;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -29,7 +31,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
     @Autowired
     private TestCsars testCsars;
     @Autowired
-    private Preferences preferences;
+    private ArtifactManagementService ams;
 
     private Csar csar;
 
@@ -74,7 +76,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         service.createTransformation(csar, passingDummy.getPlatformDetails());
         assertTrue(csar.getTransformations().get("passing") != null);
         Transformation t = csar.getTransformations().get("passing");
-        assertTrue(t.getState() == TransformationState.CREATED);
+        assertEquals(TransformationState.CREATED, t.getState());
     }
 
     @Test
@@ -86,9 +88,8 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         service.createTransformation(csar, passingDummy.getPlatformDetails());
         assertTrue(csar.getTransformations().get("passing") != null);
         Transformation t = csar.getTransformations().get("passing");
-        assertTrue(t.getState() == TransformationState.INPUT_REQUIRED);
+        assertEquals(TransformationState.INPUT_REQUIRED, t.getState());
     }
-
 
     @Test
     public void startTransformation() throws Exception {
@@ -107,7 +108,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
 
         lookForArtifactArchive(id);
     }
-    
+
     @Test
     public void startTransformationWithArtifactsExecutionFail() throws Exception {
         startTransfomationInternal(TransformationState.ERROR, failingDummyFw.getPlatformDetails());
@@ -158,7 +159,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         assertTrue(service.startTransformation(t));
         Thread.sleep(100);
         waitForTransformationStateChange(t);
-        assertTrue(t.getState() == expectedState);
+        assertEquals(expectedState, t.getState());
     }
 
     private void waitForTransformationStateChange(Transformation t) throws InterruptedException {
@@ -168,15 +169,14 @@ public class TransformationServiceImplTest extends BaseSpringTest {
     }
 
     public void lookForArtifactArchive(String id) {
-        String filename = "test-" + id+"_";
+        String filename = "test-" + id + "_";
         boolean found = false;
-        for (File file : preferences.getArtifactDir().listFiles()) {
-            if(file.getName().startsWith(filename)) {
+        for (File file : ams.getArtifactDir().listFiles()) {
+            if (file.getName().startsWith(filename)) {
                 found = true;
                 break;
             }
         }
-        assertTrue("Could not find artifact ZIP in Folder",found);
+        assertTrue("Could not find artifact ZIP in Folder", found);
     }
-
 }

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
@@ -10,7 +10,7 @@ import org.opentosca.toscana.core.dummy.DummyCsar;
 import org.opentosca.toscana.core.dummy.ExecutionDummyPlugin;
 import org.opentosca.toscana.core.testdata.TestCsars;
 import org.opentosca.toscana.core.testdata.TestPlugins;
-import org.opentosca.toscana.core.transformation.artifacts.ArtifactManagementService;
+import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyType;
@@ -31,7 +31,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
     @Autowired
     private TestCsars testCsars;
     @Autowired
-    private ArtifactManagementService ams;
+    private ArtifactService ams;
 
     private Csar csar;
 

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.core.dummy.DummyCsar;
 import org.opentosca.toscana.core.dummy.ExecutionDummyPlugin;
 import org.opentosca.toscana.core.testdata.TestCsars;
 import org.opentosca.toscana.core.testdata.TestPlugins;
+import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyType;
 import org.opentosca.toscana.core.transformation.properties.RequirementType;
@@ -30,12 +31,12 @@ public class TransformationServiceImplTest extends BaseSpringTest {
 
     private ExecutionDummyPlugin passingDummy = TestPlugins.PASSING_DUMMY;
     private ExecutionDummyPlugin failingDummy = TestPlugins.FAILING_DUMMY;
-
+    private ExecutionDummyPlugin passingDummyFw = TestPlugins.PASSING_WRITING_DUMMY;
+    private ExecutionDummyPlugin failingDummyFw = TestPlugins.FAILING_WRITING_DUMMY;
 
     @Before
     public void setUp() throws FileNotFoundException {
         csar = testCsars.getCsar(TestCsars.CSAR_YAML_VALID_SIMPLETASK);
-
     }
 
     @Test
@@ -43,11 +44,10 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         service.createTransformation(csar, TestPlugins.PLATFORM1);
         Transformation expected = new TransformationImpl(csar, TestPlugins.PLATFORM1);
         assertTrue(csar.getTransformations().containsValue(expected));
-
     }
 
     @Test
-    public void testStartTransformationInvalidState() throws Exception {
+    public void startTransformationInvalidState() throws Exception {
         service.createTransformation(csar, TestPlugins.PLATFORM1);
         Transformation t = csar.getTransformations().get(TestPlugins.PLATFORM1.id);
         t.setState(TransformationState.ERROR);
@@ -55,7 +55,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
     }
 
     @Test
-    public void testStartTransformationPropertiesNotSet() throws Exception {
+    public void startTransformationPropertiesNotSet() throws Exception {
         DummyCsar csar = new DummyCsar("test");
         csar.modelSpecificProperties = new HashSet<>();
         csar.modelSpecificProperties
@@ -87,28 +87,27 @@ public class TransformationServiceImplTest extends BaseSpringTest {
 
 
     @Test
-    public void testStartTransformationValidState() throws Exception {
-        DummyCsar csar = new DummyCsar("test");
-        service.createTransformation(csar, passingDummy.getPlatformDetails());
-        Transformation t = csar.getTransformations().get("passing");
-        assertTrue(service.startTransformation(t));
-        Thread.sleep(100);
-        waitForTransformationStateChange(t);
-        assertTrue(t.getState() == TransformationState.DONE);
+    public void startTransformation() throws Exception {
+         startTransfomationInternal(TransformationState.DONE, passingDummy.getPlatformDetails());
+    }
+    
+    @Test
+    public void startTransformationWithArtifacts() throws Exception {
+        startTransfomationInternal(TransformationState.DONE, passingDummyFw.getPlatformDetails());
     }
 
     @Test
-    public void testStartTransformationValidStateExecutionFail() throws Exception {
-        service.createTransformation(csar, failingDummy.getPlatformDetails());
-        Transformation t = csar.getTransformations().get("failing");
-        assertTrue(service.startTransformation(t));
-        Thread.sleep(100);
-        waitForTransformationStateChange(t);
-        assertTrue(t.getState() == TransformationState.ERROR);
+    public void startTransformationWithArtifactsExecutionFail() throws Exception {
+        startTransfomationInternal(TransformationState.ERROR, failingDummyFw.getPlatformDetails());
     }
 
     @Test
-    public void testExecutionStopWithSleep() throws Exception {
+    public void startTransformationExecutionFail() throws Exception {
+        startTransfomationInternal(TransformationState.ERROR, failingDummy.getPlatformDetails());
+    }
+
+    @Test
+    public void executionStopWithSleep() throws Exception {
         service.createTransformation(csar, passingDummy.getPlatformDetails());
         Transformation t = csar.getTransformations().get("passing");
         assertTrue(service.startTransformation(t));
@@ -121,27 +120,21 @@ public class TransformationServiceImplTest extends BaseSpringTest {
     }
 
     @Test
-    public void testExecutionStopWhenAlreadyDone() throws Exception {
+    public void executionStopWhenAlreadyDone() throws Exception {
         //Start a passing transformation
-        testStartTransformationValidState();
+        startTransformation();
         //Wait for it to finish
         Transformation t = csar.getTransformations().get("passing");
         assertTrue(!service.abortTransformation(t));
     }
 
     @Test
-    public void testStopNotStarted() throws Exception {
+    public void stopNotStarted() throws Exception {
         transformationCreationNoProps();
         Transformation t = csar.getTransformations().get("passing");
         assertTrue(!service.abortTransformation(t));
     }
-
-    private void waitForTransformationStateChange(Transformation t) throws InterruptedException {
-        while (t.getState() == TransformationState.TRANSFORMING) {
-            Thread.sleep(100);
-        }
-    }
-
+    
     @Test
     public void deleteTransformation() throws Exception {
         Transformation transformation = new TransformationImpl(csar, TestPlugins.PLATFORM1);
@@ -151,4 +144,20 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         assertFalse(csar.getTransformations().containsValue(transformation));
     }
 
+    private void startTransfomationInternal(TransformationState expectedState, Platform platform) throws InterruptedException {
+        DummyCsar csar = new DummyCsar("test");
+        service.createTransformation(csar, platform);
+        Transformation t = csar.getTransformations().get(platform.id);
+        assertTrue(service.startTransformation(t));
+        Thread.sleep(100);
+        waitForTransformationStateChange(t);
+        assertTrue(t.getState() == expectedState);
+    }
+
+    private void waitForTransformationStateChange(Transformation t) throws InterruptedException {
+        while (t.getState() == TransformationState.TRANSFORMING) {
+            Thread.sleep(100);
+        }
+    }
+    
 }

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
@@ -12,8 +12,10 @@ import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyType;
 import org.opentosca.toscana.core.transformation.properties.RequirementType;
+import org.opentosca.toscana.core.util.Preferences;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.HashSet;
 
@@ -26,6 +28,8 @@ public class TransformationServiceImplTest extends BaseSpringTest {
     private TransformationService service;
     @Autowired
     private TestCsars testCsars;
+    @Autowired
+    private Preferences preferences;
 
     private Csar csar;
 
@@ -88,22 +92,25 @@ public class TransformationServiceImplTest extends BaseSpringTest {
 
     @Test
     public void startTransformation() throws Exception {
-         startTransfomationInternal(TransformationState.DONE, passingDummy.getPlatformDetails());
-    }
-    
-    @Test
-    public void startTransformationWithArtifacts() throws Exception {
-        startTransfomationInternal(TransformationState.DONE, passingDummyFw.getPlatformDetails());
-    }
-
-    @Test
-    public void startTransformationWithArtifactsExecutionFail() throws Exception {
-        startTransfomationInternal(TransformationState.ERROR, failingDummyFw.getPlatformDetails());
+        startTransfomationInternal(TransformationState.DONE, passingDummy.getPlatformDetails());
     }
 
     @Test
     public void startTransformationExecutionFail() throws Exception {
         startTransfomationInternal(TransformationState.ERROR, failingDummy.getPlatformDetails());
+    }
+
+    @Test
+    public void startTransformationWithArtifacts() throws Exception {
+        startTransfomationInternal(TransformationState.DONE, passingDummyFw.getPlatformDetails());
+        String id = passingDummyFw.getIdentifier();
+
+        lookForArtifactArchive(id);
+    }
+    
+    @Test
+    public void startTransformationWithArtifactsExecutionFail() throws Exception {
+        startTransfomationInternal(TransformationState.ERROR, failingDummyFw.getPlatformDetails());
     }
 
     @Test
@@ -134,7 +141,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         Transformation t = csar.getTransformations().get("passing");
         assertTrue(!service.abortTransformation(t));
     }
-    
+
     @Test
     public void deleteTransformation() throws Exception {
         Transformation transformation = new TransformationImpl(csar, TestPlugins.PLATFORM1);
@@ -159,5 +166,17 @@ public class TransformationServiceImplTest extends BaseSpringTest {
             Thread.sleep(100);
         }
     }
-    
+
+    public void lookForArtifactArchive(String id) {
+        String filename = "test-" + id+"_";
+        boolean found = false;
+        for (File file : preferences.getArtifactDir().listFiles()) {
+            if(file.getName().startsWith(filename)) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue("Could not find artifact ZIP in Folder",found);
+    }
+
 }

--- a/core/src/test/java/org/opentosca/toscana/core/util/ZipUtilityTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/util/ZipUtilityTest.java
@@ -5,7 +5,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentosca.toscana.core.testutils.CICheckingJUnitRunner;
-import org.opentosca.toscana.core.testutils.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(CICheckingJUnitRunner.class)
 public class ZipUtilityTest {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger log = LoggerFactory.getLogger(ZipUtility.class);
 
     private File dir = new File("test-temp");
 
@@ -84,7 +83,7 @@ public class ZipUtilityTest {
         FileUtils.delete(dir);
     }
 
-    private void generateFolderStructure(
+    public static void generateFolderStructure(
         File current,
         int depth,
         int fileCount,


### PR DESCRIPTION
The PR Implements Issue #61. At least mostly it currently does not store the resulting URL because the Transformation does not have a way to set the TargetArtifact that does not cause a NullPointerException. Maybe @hnicke can have a look at this problem.

Tests have also been written using the TransformationServiceTest.

One Question is still open in this field. Do we want to compress the "artifacts" if a transformation fails and offer them for "debugging" purposes? My current implementation is handling it this way!