### PR TITLE
PluginFileAccess Redesign

### DIFF
--- a/core/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
+++ b/core/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
@@ -53,7 +53,7 @@ public class PluginFileAccess {
     }
 
     /**
-     * Returns a BufferedWriter which writes to given path
+     * Returns a BufferedWriter which can write to given path
      *
      * If necessary, creates missing subdirectories. <br>
      *
@@ -63,7 +63,7 @@ public class PluginFileAccess {
      * @return BufferedWriter which writes to target file.
      * @throws FileNotFoundException if given relativePath points to a directory
      */
-    public BufferedWriter write(String relativePath) throws IOException {
+    public BufferedWriter access(String relativePath) throws IOException {
         File target = new File(targetDir, relativePath);
         target.getParentFile().mkdirs();
         try {

--- a/core/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
+++ b/core/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
@@ -1,20 +1,21 @@
 package org.opentosca.toscana.core.plugin;
 
-import org.apache.commons.io.FileUtils;
-import org.opentosca.toscana.core.transformation.Transformation;
-import org.slf4j.Logger;
-
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.opentosca.toscana.core.transformation.Transformation;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
 
 public class PluginFileAccess {
 
     private final Logger logger;
     private final File sourceDir;
     private final File targetDir;
-
 
     public PluginFileAccess(Transformation transformation, File sourceDir, File targetDir) {
         logger = transformation.getLog().getLogger(getClass());
@@ -23,8 +24,8 @@ public class PluginFileAccess {
     }
 
     /**
-     * Copies given file or directory from the csar content directory to the transformation directory
-     * If given path specifies a directory, this directory's content gets copied aswell
+     * Copies given file or directory from the csar content directory to the transformation directory If given path
+     * specifies a directory, this directory's content gets copied aswell
      *
      * @param relativePath the path to the source file relative to the csar's content directory
      * @throws FileNotFoundException if no file or directory was found for given path
@@ -49,15 +50,12 @@ public class PluginFileAccess {
             logger.error("Failed to copy from '{}' to '{}'", source, target, e);
             throw e;
         }
-
-
     }
 
     /**
-     * Writes given InputStream to given path
-     * If necessary, creates missing subdirectories.
+     * Writes given InputStream to given path If necessary, creates missing subdirectories.
      *
-     * @param relativePath the path to the target file relative to the transformations root dir
+     * @param relativePath path to the target file, relative to the transformations root dir
      * @param inputStream  stream which will get written to file. Afterwards, this stream will be closed
      */
     public void write(String relativePath, InputStream inputStream) throws IOException {
@@ -71,5 +69,17 @@ public class PluginFileAccess {
         } finally {
             inputStream.close();
         }
+    }
+
+    /**
+     * Reads the content of a file in the csar content diretory denoted by given path.
+     *
+     * @param relativePath path to a file contained in the csar content directory, relative said directory
+     * @return InputStream of given file
+     * @throws FileNotFoundException if file denoted by given relativePath does not exist or is a directory
+     */
+    public InputStream read(String relativePath) throws FileNotFoundException {
+        File source = new File(sourceDir, relativePath);
+        return new FileInputStream(source);
     }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/util/ZipUtility.java
+++ b/core/src/main/java/org/opentosca/toscana/core/util/ZipUtility.java
@@ -18,7 +18,7 @@ public class ZipUtility {
 
     private final static Logger logger = LoggerFactory.getLogger(ZipUtility.class.getName());
     /**
-     * Size of the buffer to read/write data
+     * Size of the buffer to read/access data
      */
     private static final int BUFFER_SIZE = 4096;
 

--- a/core/src/main/java/org/opentosca/toscana/plugins/kubernetes/KubernetesPlugin.java
+++ b/core/src/main/java/org/opentosca/toscana/plugins/kubernetes/KubernetesPlugin.java
@@ -1,7 +1,5 @@
 package org.opentosca.toscana.plugins.kubernetes;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -43,10 +41,8 @@ public class KubernetesPlugin extends AbstractPlugin {
         String manual = KubernetesManualCreator.createManual(appName, (appName + "_resource.yaml"));
         String resourceFilePath = "/" + appName + "_resource.yaml";
         String manualPath = "/Readme.md";
-        InputStream inResourceFile = new ByteArrayInputStream(resourceFile.getBytes("UTF-8"));
-        InputStream inManual = new ByteArrayInputStream(manual.getBytes("UTF-8"));
-        fileAccess.write(manualPath, inManual);
-        fileAccess.write(resourceFilePath, inResourceFile);
+        fileAccess.write(manualPath).write(manual);
+        fileAccess.write(resourceFilePath).write(resourceFile);
         List<String> dockerFilePaths = dockerApp.getDependencies();
         for (int i = 0; i < dockerFilePaths.size(); i++) {
             fileAccess.copy(dockerFilePaths.get(i));

--- a/core/src/main/java/org/opentosca/toscana/plugins/kubernetes/KubernetesPlugin.java
+++ b/core/src/main/java/org/opentosca/toscana/plugins/kubernetes/KubernetesPlugin.java
@@ -41,8 +41,8 @@ public class KubernetesPlugin extends AbstractPlugin {
         String manual = KubernetesManualCreator.createManual(appName, (appName + "_resource.yaml"));
         String resourceFilePath = "/" + appName + "_resource.yaml";
         String manualPath = "/Readme.md";
-        fileAccess.write(manualPath).write(manual);
-        fileAccess.write(resourceFilePath).write(resourceFile);
+        fileAccess.access(manualPath).write(manual);
+        fileAccess.access(resourceFilePath).write(resourceFile);
         List<String> dockerFilePaths = dockerApp.getDependencies();
         for (int i = 0; i < dockerFilePaths.size(); i++) {
             fileAccess.copy(dockerFilePaths.get(i));

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/ExecutionDummyPlugin.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/ExecutionDummyPlugin.java
@@ -1,13 +1,11 @@
 package org.opentosca.toscana.core.dummy;
 
-import java.io.InputStream;
 import java.util.HashSet;
 
 import org.opentosca.toscana.core.plugin.AbstractPlugin;
 import org.opentosca.toscana.core.transformation.TransformationContext;
 import org.opentosca.toscana.core.transformation.properties.Property;
 
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 
 public class ExecutionDummyPlugin extends AbstractPlugin {
@@ -39,8 +37,7 @@ public class ExecutionDummyPlugin extends AbstractPlugin {
     public void transform(TransformationContext transformation) throws Exception {
         Logger logger = transformation.getLogger(getClass());
         int i = 0;
-        InputStream stream = IOUtils.toInputStream("some transformation result");
-        transformation.getPluginFileAccess().write("some-output-file", stream);
+        transformation.getPluginFileAccess().write("some-output-file").append("some transformation result").close();
         logger.info("Waiting 50ms until completion");
         while (!Thread.currentThread().isInterrupted() && i < 5) {
             Thread.sleep(10);

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/ExecutionDummyPlugin.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/ExecutionDummyPlugin.java
@@ -37,7 +37,7 @@ public class ExecutionDummyPlugin extends AbstractPlugin {
     public void transform(TransformationContext transformation) throws Exception {
         Logger logger = transformation.getLogger(getClass());
         int i = 0;
-        transformation.getPluginFileAccess().write("some-output-file").append("some transformation result").close();
+        transformation.getPluginFileAccess().access("some-output-file").append("some transformation result").close();
         logger.info("Waiting 50ms until completion");
         while (!Thread.currentThread().isInterrupted() && i < 5) {
             Thread.sleep(10);

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/FileCreatingExceutionDummyPlugin.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/FileCreatingExceutionDummyPlugin.java
@@ -1,6 +1,5 @@
 package org.opentosca.toscana.core.dummy;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Random;
 
@@ -31,6 +30,6 @@ public class FileCreatingExceutionDummyPlugin extends ExecutionDummyPlugin {
     public void writeFilepath(TransformationContext transformation, Random rnd, String path) throws IOException {
         byte[] data = new byte[1024 * 10];
         rnd.nextBytes(data);
-        transformation.getPluginFileAccess().write(path, new ByteArrayInputStream(data));
+        transformation.getPluginFileAccess().write(path).append(new String(data)).close();
     }
 }

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/FileCreatingExceutionDummyPlugin.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/FileCreatingExceutionDummyPlugin.java
@@ -30,6 +30,6 @@ public class FileCreatingExceutionDummyPlugin extends ExecutionDummyPlugin {
     public void writeFilepath(TransformationContext transformation, Random rnd, String path) throws IOException {
         byte[] data = new byte[1024 * 10];
         rnd.nextBytes(data);
-        transformation.getPluginFileAccess().write(path).append(new String(data)).close();
+        transformation.getPluginFileAccess().access(path).append(new String(data)).close();
     }
 }

--- a/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class PluginFileAccessTest extends BaseSpringTest {
@@ -116,5 +117,24 @@ public class PluginFileAccessTest extends BaseSpringTest {
         File targetFile = new File(transformationRootDir, path);
         assertTrue(targetFile.isFile());
         assertEquals(streamContent, FileUtils.readFileToString(targetFile));
+    }
+
+    @Test
+    public void readSuccessful() throws IOException {
+        String path = "file";
+        File file = new File(csarContentDir, path);
+        FileUtils.copyInputStreamToFile(inputStream, file);
+        InputStream is = access.read(path);
+        String result = IOUtils.toString(is);
+
+        assertNotNull(result);
+
+        assertEquals(streamContent, result);
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void readFileNotExists() throws FileNotFoundException {
+        String path = "nonexistent-file";
+        access.read(path);
     }
 }

--- a/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
@@ -98,7 +98,7 @@ public class PluginFileAccessTest extends BaseSpringTest {
 
     @Test
     public void write() throws Exception {
-        access.write(streamTargetRelativePath).append(streamContent).close();
+        access.access(streamTargetRelativePath).append(streamContent).close();
         assertTrue(streamTargetFile.isFile());
         assertEquals(streamContent, FileUtils.readFileToString(streamTargetFile));
     }
@@ -106,13 +106,13 @@ public class PluginFileAccessTest extends BaseSpringTest {
     @Test(expected = IOException.class)
     public void writePathIsDirectoryThrowsException() throws IOException {
         streamTargetFile.mkdir();
-        access.write(streamTargetRelativePath);
+        access.access(streamTargetRelativePath);
     }
 
     @Test
     public void writeSubDirectoriesGetAutomaticallyCreated() throws IOException {
         String path = "test/some/subdirs/filename";
-        access.write(path).append(streamContent).close();
+        access.access(path).append(streamContent).close();
         File targetFile = new File(transformationRootDir, path);
         assertTrue(targetFile.isFile());
         assertEquals(streamContent, FileUtils.readFileToString(targetFile));

--- a/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
@@ -98,7 +98,7 @@ public class PluginFileAccessTest extends BaseSpringTest {
 
     @Test
     public void write() throws Exception {
-        access.write(streamTargetRelativePath, inputStream);
+        access.write(streamTargetRelativePath).append(streamContent).close();
         assertTrue(streamTargetFile.isFile());
         assertEquals(streamContent, FileUtils.readFileToString(streamTargetFile));
     }
@@ -106,14 +106,13 @@ public class PluginFileAccessTest extends BaseSpringTest {
     @Test(expected = IOException.class)
     public void writePathIsDirectoryThrowsException() throws IOException {
         streamTargetFile.mkdir();
-        access.write(streamTargetRelativePath, inputStream);
+        access.write(streamTargetRelativePath);
     }
 
     @Test
     public void writeSubDirectoriesGetAutomaticallyCreated() throws IOException {
         String path = "test/some/subdirs/filename";
-        InputStream stream = IOUtils.toInputStream(streamContent, "UTF-8");
-        access.write(path, stream);
+        access.write(path).append(streamContent).close();
         File targetFile = new File(transformationRootDir, path);
         assertTrue(targetFile.isFile());
         assertEquals(streamContent, FileUtils.readFileToString(targetFile));
@@ -124,16 +123,15 @@ public class PluginFileAccessTest extends BaseSpringTest {
         String path = "file";
         File file = new File(csarContentDir, path);
         FileUtils.copyInputStreamToFile(inputStream, file);
-        InputStream is = access.read(path);
-        String result = IOUtils.toString(is);
+        String result = access.read(path);
 
         assertNotNull(result);
 
         assertEquals(streamContent, result);
     }
 
-    @Test(expected = FileNotFoundException.class)
-    public void readFileNotExists() throws FileNotFoundException {
+    @Test(expected = IOException.class)
+    public void readFileNotExists() throws IOException {
         String path = "nonexistent-file";
         access.read(path);
     }


### PR DESCRIPTION
Redesigned PluginFileAccess class. While adding the 'read' method I realized that using an InputStream for the write operation is really stupid.
- Change `write(String relativePath, InputStream stream)` to `access(String relativePath): BufferedWriter`
    - usage: `fileAccess.access("path/to/file").append("filecontent").close();`
- Add read method: `read(String relativePath): String`