### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 The TOSCAna framework allows the transformation of TOSCA models into other cloud formats.
 Currently, it aims to support multiple cloud ecosystems, with Kubernetes, CloudFoundry, AWS CloudFormation being the first.
 ## Project Structure
-- [`docs/user`](docs/user) - Documentation aimed at users
 - [`docs/dev`](docs/dev) - Documentation aimed at developers
 - [`core`](core) - Folder for the core - Module
 - [`cli`](cli) - Folder for the CLI - Module
@@ -18,8 +17,8 @@ Tools that are used in this project.
 - IDE: [IntelliJ](https://www.jetbrains.com/idea/)
 - UML Modelling: [Lucidchart](https://www.lucidchart.com/)
 - Project management: [ZenHub](https://www.zenhub.com/)
-- CI: [TravisCI](https://travis-ci.org/nfode/stupro_toscana_vorprojekt)
-- Code analysis: [Codacy](https://www.codacy.com/app/nfode/stupro_toscana_vorprojekt/dashboard)
-- Code coverage: [Codecov](https://codecov.io/gh/nfode/stupro_toscana_vorprojekt), [Get browser extension](https://github.com/codecov/browser-extension)
+- CI: [TravisCI](https://travis-ci.org/StuPro-TOSCAna/TOSCAna)
+- Code analysis: [Codacy](https://www.codacy.com/app/stupro-toscana/TOSCAna/dashboard)
+- Code coverage: [Codecov](https://codecov.io/gh/StuPro-TOSCAna/TOSCAna), [Get browser extension](https://github.com/codecov/browser-extension)
 ## License
 TOSCAna is under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
Updates the TravisCI, Codacy and Codecov links in the readme to link to the TOSCAna project instead of the preliminary design study.

One more person should check the links, other than that it should be ready to merge.