### PR TITLE
Rework properties Request Mappings and property behaviour

### DIFF
--- a/core/src/main/java/org/opentosca/toscana/core/api/CsarController.java
+++ b/core/src/main/java/org/opentosca/toscana/core/api/CsarController.java
@@ -124,7 +124,7 @@ public class CsarController {
                 throw new CsarNameAlreadyUsedException();
             }
             return ResponseEntity.ok().build();
-        } catch (InvalidCsarException e) {
+        } catch (InvalidCsarException | RuntimeException e) {
             throw e;
         } catch (Exception e) {
             log.error("Reading of uploaded CSAR Failed", e);

--- a/core/src/main/java/org/opentosca/toscana/core/api/model/GetPropertiesResponse.java
+++ b/core/src/main/java/org/opentosca/toscana/core/api/model/GetPropertiesResponse.java
@@ -42,17 +42,20 @@ public class GetPropertiesResponse extends ResourceSupport {
         private String type;
         private String description;
         private boolean required;
+        private String value;
 
         public PropertyWrap(
             @JsonProperty("key") String key,
             @JsonProperty("type") String type,
             @JsonProperty("description") String description,
+            @JsonProperty("value") String value,
             @JsonProperty("required") boolean required
         ) {
             this.key = key;
             this.type = type;
             this.description = description;
             this.required = required;
+            this.value = value;
         }
 
         @JsonProperty("key")
@@ -73,6 +76,11 @@ public class GetPropertiesResponse extends ResourceSupport {
         @JsonProperty("required")
         public boolean isRequired() {
             return required;
+        }
+
+        @JsonProperty("value")
+        public String getValue() {
+            return value;
         }
     }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/Transformation.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/Transformation.java
@@ -5,7 +5,6 @@ import org.opentosca.toscana.core.transformation.artifacts.TargetArtifact;
 import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.PropertyInstance;
-import org.opentosca.toscana.core.transformation.properties.RequirementType;
 
 public interface Transformation {
 
@@ -38,26 +37,23 @@ public interface Transformation {
     PropertyInstance getProperties();
 
     /**
-     * Checks if all Properties for the given Requirement type are set.
-     * <p>
-     * This is just a "shortcut" for <code>getProperties().allPropertiesSetForType(type)</code>
+     * Checks if all Properties for the given Requirement type are set. <p> This is just a "shortcut" for
+     * <code>getProperties().allPropertiesSet(type)</code>
      *
      * @return true if all properties have been set and are valid, false otherwise
      */
-    default boolean allPropertiesSet(RequirementType type) {
-        return getProperties().allPropertiesSetForType(type);
+    default boolean allPropertiesSet() {
+        return getProperties().allPropertiesSet();
     }
 
-
     /**
-     * Checks if all Properties for the given Requirement type are set.
-     * <p>
-     * This is just a "shortcut" for <code>getProperties().allRequiredPropertiesSetForType(type)</code>
+     * Checks if all Properties for the given Requirement type are set. <p> This is just a "shortcut" for
+     * <code>getProperties().allRequiredPropertiesSet(type)</code>
      *
      * @return true if all required properties have been set and are valid, false otherwise
      */
-    default boolean allRequiredPropertiesSet(RequirementType type) {
-        return getProperties().allRequiredPropertiesSetForType(type);
+    default boolean allRequiredPropertiesSet() {
+        return getProperties().allRequiredPropertiesSet();
     }
 
     /**

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
@@ -20,7 +20,7 @@ class TransformationImpl implements Transformation {
     private final Platform targetPlatform;
     private final Log log;
     private final PropertyInstance properties;
-    private TransformationState state = TransformationState.CREATED;
+    private TransformationState state = TransformationState.READY;
     private TargetArtifact targetArtifact;
 
     /**
@@ -40,12 +40,7 @@ class TransformationImpl implements Transformation {
         properties.addAll(targetPlatform.getProperties());
 
         //Create property instance
-        this.properties = new PropertyInstance(properties);
-
-        //Check if the property list is empty
-        if (!properties.isEmpty()) {
-            state = TransformationState.INPUT_REQUIRED;
-        }
+        this.properties = new PropertyInstance(properties,this );
     }
 
     @Override

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationServiceImpl.java
@@ -1,5 +1,11 @@
 package org.opentosca.toscana.core.transformation;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import org.opentosca.toscana.core.api.exceptions.PlatformNotFoundException;
 import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.csar.CsarDao;
@@ -7,18 +13,12 @@ import org.opentosca.toscana.core.plugin.PluginService;
 import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
 import org.opentosca.toscana.core.transformation.execution.ExecutionTask;
 import org.opentosca.toscana.core.transformation.platform.Platform;
-import org.opentosca.toscana.core.transformation.properties.RequirementType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 @Service
 public class TransformationServiceImpl implements TransformationService {
@@ -55,9 +55,9 @@ public class TransformationServiceImpl implements TransformationService {
     public boolean startTransformation(Transformation transformation) {
         //Only start the transformation if the input has been validated or the 
         //transformation does not need any addidtional properties
-        if (transformation.getState() == TransformationState.CREATED
+        if (transformation.getState() == TransformationState.READY
             || (transformation.getState() == TransformationState.INPUT_REQUIRED
-            && transformation.allRequiredPropertiesSet(RequirementType.TRANSFORMATION))) {
+            && transformation.allRequiredPropertiesSet())) {
             Future<?> taskFuture = executor.submit(
                 new ExecutionTask(
                     transformation,

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationState.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationState.java
@@ -9,17 +9,10 @@ public enum TransformationState {
     /**
      * The transformation is in this state, once it has been created but it has not been started or scheduled
      */
-    CREATED,
-    /**
-     * The transformation is in this state, once the transformation has been scheduled
-     * but the transformaion or deployment process was not instantiated yet.
-     * <p>
-     * If the Task performed is a transformation
-     */
     READY,
     TRANSFORMING,
     DONE,
     ERROR,
-    INTERUPTED,
+//    INTERUPTED,
     INPUT_REQUIRED
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/platform/Platform.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/platform/Platform.java
@@ -1,11 +1,10 @@
 package org.opentosca.toscana.core.transformation.platform;
 
-import org.opentosca.toscana.core.transformation.properties.Property;
-import org.opentosca.toscana.core.transformation.properties.RequirementType;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.opentosca.toscana.core.transformation.properties.Property;
 
 public class Platform {
 
@@ -41,20 +40,11 @@ public class Platform {
         this(id, name, new HashSet<>());
     }
 
-
     /**
      * @return a list of properties which are necessary for a transformation to this platform.
      */
     public Set<Property> getProperties() {
         return Collections.unmodifiableSet(properties);
-    }
-
-    public Set<Property> getPropertiesForRequirementType(RequirementType type) {
-        HashSet<Property> filteredProperties = new HashSet<>();
-        properties.stream()
-            .filter((e) -> e.getRequirementType() == type)
-            .forEach(filteredProperties::add);
-        return Collections.unmodifiableSet(filteredProperties);
     }
 
     public String toString() {

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/properties/Property.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/properties/Property.java
@@ -9,7 +9,6 @@ package org.opentosca.toscana.core.transformation.properties;
 public class Property {
     private String key;
     private PropertyType type;
-    private RequirementType requirementType;
 
     private String description;
     private boolean required;
@@ -19,16 +18,14 @@ public class Property {
      *
      * @param key             the unique key of the property
      * @param type            the expected "datatype" of the property value
-     * @param requirementType classifies the property for a specific type of process (Transformation or deployment)
      * @param description     a short description of the property (should not exceed 200 characters, does not get
      *                        checked tough)
      * @param required        determines if the property is required or not
      */
-    public Property(String key, PropertyType type, RequirementType requirementType,
+    public Property(String key, PropertyType type,
                     String description, boolean required) {
         this.key = key;
         this.type = type;
-        this.requirementType = requirementType;
         this.description = description;
         this.required = required;
     }
@@ -38,10 +35,9 @@ public class Property {
      *
      * @param key             the unique key of the property
      * @param type            the expected "datatype" of the property value
-     * @param requirementType classifies the property for a specific type of process (Transformation or deployment)
      */
-    public Property(String key, PropertyType type, RequirementType requirementType) {
-        this(key, type, requirementType, "", true);
+    public Property(String key, PropertyType type) {
+        this(key, type, "", true);
     }
 
     public String getKey() {
@@ -50,10 +46,6 @@ public class Property {
 
     public PropertyType getType() {
         return type;
-    }
-
-    public RequirementType getRequirementType() {
-        return requirementType;
     }
 
     public String getDescription() {

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/properties/RequirementType.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/properties/RequirementType.java
@@ -1,7 +1,0 @@
-package org.opentosca.toscana.core.transformation.properties;
-
-public enum RequirementType {
-    NEVER,
-    TRANSFORMATION,
-    DEPLOYMENT;
-}

--- a/core/src/test/java/org/opentosca/toscana/core/api/CsarControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/CsarControllerTest.java
@@ -76,7 +76,7 @@ public class CsarControllerTest extends BaseSpringTest{
         resultActions.andReturn();
     }
 
-    //@Test
+    @Test
     public void uploadTest() throws Exception {
         //Generate 10 MiB of "Random" (seeded) data
         byte[] data = new byte[(int) (Math.pow(2, 20) * 10)];
@@ -114,7 +114,7 @@ public class CsarControllerTest extends BaseSpringTest{
         }
     }
 
-    //@Test
+    @Test
     public void uploadTestArchiveAlreadyExists() throws Exception {
         //Generate 10 KiB of "Random" (seeded) data
         byte[] data = new byte[(int) (Math.pow(2, 10) * 10)];

--- a/core/src/test/java/org/opentosca/toscana/core/api/TransformationControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/TransformationControllerTest.java
@@ -12,10 +12,9 @@ import org.opentosca.toscana.core.dummy.DummyCsarService;
 import org.opentosca.toscana.core.dummy.DummyPlatformService;
 import org.opentosca.toscana.core.dummy.DummyTransformation;
 import org.opentosca.toscana.core.dummy.DummyTransformationService;
-import org.opentosca.toscana.core.transformation.TransformationService;
-import org.opentosca.toscana.core.transformation.TransformationState;
 import org.opentosca.toscana.core.transformation.platform.PlatformService;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,9 +23,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.opentosca.toscana.core.transformation.TransformationState.TRANSFORMING;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -51,10 +54,26 @@ public class TransformationControllerTest extends BaseSpringTest {
         "\t\t\"unsigned_integer_property\": \"-1337\"\n" +
         "\t}\n" +
         "}";
+    public static final String VALID_CSAR_NAME = "k8s-cluster";
+    public static final String VALID_PLATFORM_NAME = "p-a";
+    public static final String START_TRANSFORMATION_VALID_URL = "/csars/k8s-cluster/transformations/p-a/start";
+    public static final String GET_PROPERTIES_VALID_URL = "/csars/k8s-cluster/transformations/p-a/properties";
+    public static final String DEFAULT_CHARSET_HAL_JSON = "application/hal+json;charset=UTF-8";
+    public static final String ARTIFACT_RESPONSE_EXPCETED_URL = "http://localhost/csars/k8s-cluster/transformations/p-a/artifact";
+    public static final String GET_ARTIFACTS_VALID_URL = "/csars/k8s-cluster/transformations/p-a/artifact";
+    public static final String GET_LOGS_AT_START_ZERO_VALID_URL = "/csars/k8s-cluster/transformations/p-a/logs?start=0";
+    public static final String DELETE_TRANSFORMATION_VALID_URL = "/csars/k8s-cluster/transformations/p-a/delete";
+    public static final String TRANSFORMATION_DETAILS_VALID_URL = "/csars/k8s-cluster/transformations/p-a";
+    public static final String APPLICATION_HAL_JSON_MIME_TYPE = "application/hal+json";
+    public static final String LIST_TRANSFORMATIONS_VALID_URL = "/csars/k8s-cluster/transformations/";
+    public static final String LIST_TRANSFORMATIONS_EXPECTED_URL = "http://localhost/csars/k8s-cluster/transformations/";
+    public static final String CREATE_CSAR_VALID_URL = "/csars/k8s-cluster/transformations/p-a/create";
+    public static final String PLATFORM_NOT_FOUND_URL = "/csars/k8s-cluster/transformations/p-z";
+    public static final String CSAR_NOT_FOUND_URL = "/csars/keinechtescsar/transformations";
 
     private TransformationController controller;
     private CsarService csarService;
-    private TransformationService transformationService;
+    private DummyTransformationService transformationService;
     private PlatformService platformService;
     private MockMvc mvc;
 
@@ -69,21 +88,53 @@ public class TransformationControllerTest extends BaseSpringTest {
         mvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
+    //<editor-fold desc="Start transformation tests">
+
+    @Test
+    public void testStartTransformationSuccess() throws Exception {
+        preInitNonCreationTests();
+        transformationService.setStartReturnValue(true);
+        mvc.perform(
+            post(START_TRANSFORMATION_VALID_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(VALID_PROPERTY_INPUT)
+        ).andDo(print())
+            .andExpect(status().is(200))
+            .andExpect(content().bytes(new byte[0]))
+            .andReturn();
+        assertEquals(TRANSFORMING,
+            csarService.getCsar(VALID_CSAR_NAME).getTransformations().get(VALID_PLATFORM_NAME).getState());
+    }
+
+    @Test
+    public void testStartTransformationFail() throws Exception {
+        preInitNonCreationTests();
+        transformationService.setStartReturnValue(false);
+        mvc.perform(
+            post(START_TRANSFORMATION_VALID_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(VALID_PROPERTY_INPUT)
+        ).andDo(print())
+            .andExpect(status().is(400))
+            .andExpect(content().bytes(new byte[0]))
+            .andReturn();
+        assertNotEquals(TRANSFORMING,
+            csarService.getCsar(VALID_CSAR_NAME).getTransformations().get(VALID_PLATFORM_NAME).getState());
+    }
+
+    //</editor-fold>
+
     //<editor-fold desc="Property tests">
     @Test
     public void setTransformationProperties() throws Exception {
         preInitNonCreationTests();
         mvc.perform(
-            put("/csars/k8s-cluster/transformations/p-a/properties")
+            put(GET_PROPERTIES_VALID_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(VALID_PROPERTY_INPUT)
         ).andDo(print())
             .andExpect(status().is(200))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-            .andExpect(jsonPath("$.valid_inputs.name_property").value(true))
-            .andExpect(jsonPath("$.valid_inputs.text_property").value(true))
-            .andExpect(jsonPath("$.valid_inputs.secret_property").value(true))
-            .andExpect(jsonPath("$.valid_inputs.unsigned_integer_property").value(true))
+            .andExpect(content().bytes(new byte[0]))
             .andReturn();
     }
 
@@ -91,7 +142,7 @@ public class TransformationControllerTest extends BaseSpringTest {
     public void setTransformationPropertiesInvalidInput() throws Exception {
         preInitNonCreationTests();
         mvc.perform(
-            put("/csars/k8s-cluster/transformations/p-a/properties")
+            put(GET_PROPERTIES_VALID_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(INVALID_PROPERTY_INPUT)
         ).andDo(print())
@@ -108,16 +159,17 @@ public class TransformationControllerTest extends BaseSpringTest {
     public void getTransformationProperties() throws Exception {
         preInitNonCreationTests();
         mvc.perform(
-            get("/csars/k8s-cluster/transformations/p-a/properties")
+            get(GET_PROPERTIES_VALID_URL)
         ).andDo(print())
             .andExpect(status().is(200))
-            .andExpect(content().contentType("application/hal+json;charset=UTF-8"))
+            .andExpect(content().contentType(DEFAULT_CHARSET_HAL_JSON))
             .andExpect(jsonPath("$.properties").isArray())
             .andExpect(jsonPath("$.properties").isNotEmpty())
             .andExpect(jsonPath("$.properties[0].key").isString())
             .andExpect(jsonPath("$.properties[0].type").isString())
             .andExpect(jsonPath("$.properties[0].description").isString())
             .andExpect(jsonPath("$.properties[0].required").isBoolean())
+            .andExpect(jsonPath("$.properties[0].value").doesNotExist()) //Check that the value is null
             .andExpect(jsonPath("$.links[0].rel").value("self"))
             .andExpect(jsonPath("$.links[0].href")
                 .value("http://localhost/csars/k8s-cluster/transformations/p-a/properties"))
@@ -125,59 +177,79 @@ public class TransformationControllerTest extends BaseSpringTest {
     }
 
     @Test
-    public void getTransformationPropertiesInvalidState() throws Exception {
+    public void getTransformationPropertyValues() throws Exception {
         preInitNonCreationTests();
-        ((DummyTransformation) csarService.getCsar("k8s-cluster").getTransformations().get("p-a"))
-            .setState(TransformationState.READY);
-        mvc.perform(
-            get("/csars/k8s-cluster/transformations/p-a/properties")
+        //Set a Property value
+        csarService.getCsar(VALID_CSAR_NAME)
+            .getTransformations().get(VALID_PLATFORM_NAME)
+            .getProperties().setPropertyValue("secret_property", "geheim");
+        //Perform a request
+        MvcResult result = mvc.perform(
+            get(GET_PROPERTIES_VALID_URL)
         ).andDo(print())
-            .andExpect(status().is(400))
+            .andExpect(status().is(200))
+            .andExpect(content().contentType(DEFAULT_CHARSET_HAL_JSON))
             .andReturn();
+        // Check if only one value is set (the one that has been set above) and the others are not!
+        JSONArray obj = new JSONObject(result.getResponse().getContentAsString()).getJSONArray("properties");
+        boolean valueFound = false;
+        boolean restNull = true;
+        for (int i = 0; i < obj.length(); i++) {
+            JSONObject content = obj.getJSONObject(i);
+            if (content.getString("key").equals("secret_property")) {
+                valueFound = content.getString("value").equals("geheim");
+            } else {
+                restNull = restNull && content.isNull("value");
+            }
+        }
+        assertTrue("Could not find valid value in property list", valueFound);
+        assertTrue("Not all other values in property list are null", restNull);
     }
 
     //</editor-fold>
+    
     //<editor-fold desc="Test Artifact Retrieval">
     @Test
     public void retrieveArtifact() throws Exception {
         preInitNonCreationTests();
-        ((DummyTransformation) csarService.getCsar("k8s-cluster").getTransformations().get("p-a"))
+        ((DummyTransformation) csarService.getCsar(VALID_CSAR_NAME).getTransformations().get(VALID_PLATFORM_NAME))
             .setReturnTargetArtifact(true);
         mvc.perform(
-            get("/csars/k8s-cluster/transformations/p-a/artifact")
+            get(GET_ARTIFACTS_VALID_URL)
         ).andDo(print())
             .andExpect(status().is(200))
-            .andExpect(content().contentType("application/hal+json;charset=UTF-8"))
+            .andExpect(content().contentType(DEFAULT_CHARSET_HAL_JSON))
             .andExpect(jsonPath("$.access_url").isString())
             .andExpect(jsonPath("$.links").isArray())
             .andExpect(jsonPath("$.links[0].rel").value("self"))
             .andExpect(jsonPath("$.links[0].href")
-                .value("http://localhost/csars/k8s-cluster/transformations/p-a/artifact"))
+                .value(ARTIFACT_RESPONSE_EXPCETED_URL))
             .andReturn();
     }
 
     @Test
     public void retrieveArtifactNotFinished() throws Exception {
         preInitNonCreationTests();
-        ((DummyTransformation) csarService.getCsar("k8s-cluster").getTransformations().get("p-a"))
+        ((DummyTransformation) csarService.getCsar(VALID_CSAR_NAME).getTransformations().get(VALID_PLATFORM_NAME))
             .setReturnTargetArtifact(false);
         mvc.perform(
-            get("/csars/k8s-cluster/transformations/p-a/artifact")
+            get(GET_ARTIFACTS_VALID_URL)
         ).andDo(print())
             .andExpect(status().is(400))
             .andReturn();
     }
 
     //</editor-fold>
+    
     //<editor-fold desc="Test Transformation Logs">
     @Test
     public void retrieveTransformationLogs() throws Exception {
         preInitNonCreationTests();
         mvc.perform(
-            get("/csars/k8s-cluster/transformations/p-a/logs?start=0")
+            get(GET_LOGS_AT_START_ZERO_VALID_URL)
         ).andDo(print())
             .andExpect(status().is(200))
-            .andExpect(content().contentType("application/hal+json;charset=UTF-8"))
+            .andExpect(content().contentType(DEFAULT_CHARSET_HAL_JSON))
             .andExpect(jsonPath("$.start").value(0))
             .andExpect(jsonPath("$.end").isNumber())
             .andExpect(jsonPath("$.logs").isArray())
@@ -189,54 +261,55 @@ public class TransformationControllerTest extends BaseSpringTest {
     }
 
     //</editor-fold>
+    
     //<editor-fold desc="Delete Transformation Tests">
     @Test
     public void deleteTransformation() throws Exception {
         preInitNonCreationTests();
         //Set the return value of the delete method
-        ((DummyTransformationService) transformationService).setReturnValue(true);
+        ((DummyTransformationService) transformationService).setDeleteReturnValue(true);
         //Execute Request
         mvc.perform(
-            delete("/csars/k8s-cluster/transformations/p-a/delete")
+            delete(DELETE_TRANSFORMATION_VALID_URL)
         ).andDo(print())
             .andExpect(status().is(200))
             .andReturn();
     }
 
     @Test
-    public void deleteTransformationServerError() throws Exception {
+    public void deleteTransformationStillRunning() throws Exception {
         preInitNonCreationTests();
         //Set the return value of the delete method
-        ((DummyTransformationService) transformationService).setReturnValue(false);
+        ((DummyTransformationService) transformationService).setDeleteReturnValue(false);
         //Execute Request
         mvc.perform(
-            delete("/csars/k8s-cluster/transformations/p-a/delete")
+            delete(DELETE_TRANSFORMATION_VALID_URL)
         ).andDo(print())
-            .andExpect(status().is(500))
+            .andExpect(status().is(400))
             .andReturn();
     }
-
     //</editor-fold>
+    
     //<editor-fold desc="Transformation Details Test">
     @Test
     public void transformationDetails() throws Exception {
         preInitNonCreationTests();
         MvcResult result = mvc.perform(
-            get("/csars/k8s-cluster/transformations/p-a").accept("application/hal+json")
+            get(TRANSFORMATION_DETAILS_VALID_URL).accept(APPLICATION_HAL_JSON_MIME_TYPE)
         )
             .andDo(print())
             .andExpect(status().is(200))
-            .andExpect(content().contentType("application/hal+json;charset=UTF-8"))
+            .andExpect(content().contentType(DEFAULT_CHARSET_HAL_JSON))
             .andExpect(jsonPath("$.progress").value(0))
-            .andExpect(jsonPath("$.platform").value("p-a"))
+            .andExpect(jsonPath("$.platform").value(VALID_PLATFORM_NAME))
             .andExpect(jsonPath("$.status").value("INPUT_REQUIRED"))
             .andReturn();
         JSONObject object = new JSONObject(result.getResponse().getContentAsString());
         HALRelationUtils.validateRelations(
             object.getJSONArray("links"),
             getLinkRelationsForTransformationDetails(),
-            "k8s-cluster",
-            "p-a"
+            VALID_CSAR_NAME,
+            VALID_PLATFORM_NAME
         );
     }
 
@@ -250,24 +323,24 @@ public class TransformationControllerTest extends BaseSpringTest {
         map.put("delete", "http://localhost/csars/%s/transformations/%s/delete");
         return map;
     }
-
     //</editor-fold>
+    
     //<editor-fold desc="List Transformation Tests">
     @Test
     public void listTransformations() throws Exception {
         preInitNonCreationTests();
         mvc.perform(
-            get("/csars/k8s-cluster/transformations/").accept("application/hal+json")
+            get(LIST_TRANSFORMATIONS_VALID_URL).accept(APPLICATION_HAL_JSON_MIME_TYPE)
         )
             .andDo(print())
             .andExpect(status().is(200))
-            .andExpect(content().contentType("application/hal+json;charset=UTF-8"))
+            .andExpect(content().contentType(DEFAULT_CHARSET_HAL_JSON))
             .andExpect(jsonPath("$.content").isArray())
             .andExpect(jsonPath("$.content[0]").exists())
             .andExpect(jsonPath("$.content[1]").exists())
             .andExpect(jsonPath("$.content[2]").doesNotExist())
             .andExpect(jsonPath("$.links[0].href")
-                .value("http://localhost/csars/k8s-cluster/transformations/"))
+                .value(LIST_TRANSFORMATIONS_EXPECTED_URL))
             .andExpect(jsonPath("$.links[0].rel").value("self"))
             .andExpect(jsonPath("$.links[1]").doesNotExist())
             .andReturn();
@@ -276,89 +349,89 @@ public class TransformationControllerTest extends BaseSpringTest {
     @Test
     public void listEmptyTransformations() throws Exception {
         mvc.perform(
-            get("/csars/k8s-cluster/transformations/").accept("application/hal+json;charset=UTF-8")
+            get(LIST_TRANSFORMATIONS_VALID_URL).accept(DEFAULT_CHARSET_HAL_JSON)
         )
             .andDo(print())
             .andExpect(status().is(200))
-            .andExpect(content().contentType("application/hal+json;charset=UTF-8"))
+            .andExpect(content().contentType(DEFAULT_CHARSET_HAL_JSON))
             .andExpect(jsonPath("$.content").isArray())
             .andExpect(jsonPath("$.content[0]").doesNotExist())
             .andExpect(jsonPath("$.links[0].href")
-                .value("http://localhost/csars/k8s-cluster/transformations/"))
+                .value(LIST_TRANSFORMATIONS_EXPECTED_URL))
             .andExpect(jsonPath("$.links[0].rel").value("self"))
             .andExpect(jsonPath("$.links[1]").doesNotExist())
             .andReturn();
     }
-
     //</editor-fold>
+    
     //<editor-fold desc="Create Transformation Tests">
     @Test
     public void createTransformation() throws Exception {
         //Make sure no previous transformations are present
-        assertTrue(csarService.getCsar("k8s-cluster").getTransformations().entrySet().size() == 0);
+        assertTrue(csarService.getCsar(VALID_CSAR_NAME).getTransformations().entrySet().size() == 0);
         //Call creation Request
-        mvc.perform(put("/csars/k8s-cluster/transformations/p-a/create"))
+        mvc.perform(put(CREATE_CSAR_VALID_URL))
             .andDo(print())
             .andExpect(status().is(200))
             .andExpect(content().bytes(new byte[0]))
             .andReturn();
         //Check if the transformation has been added to the archive
-        assertTrue(csarService.getCsar("k8s-cluster").getTransformations().entrySet().size() == 1);
-        assertTrue(csarService.getCsar("k8s-cluster").getTransformations().get("p-a") != null);
+        assertTrue(csarService.getCsar(VALID_CSAR_NAME).getTransformations().entrySet().size() == 1);
+        assertTrue(csarService.getCsar(VALID_CSAR_NAME).getTransformations().get(VALID_PLATFORM_NAME) != null);
     }
 
     @Test
     public void createTransformationTwice() throws Exception {
         //call the first time
-        mvc.perform(put("/csars/k8s-cluster/transformations/p-a/create"))
+        mvc.perform(put(CREATE_CSAR_VALID_URL))
             .andDo(print())
             .andExpect(status().is(200))
             .andExpect(content().bytes(new byte[0]))
             .andReturn();
         //Call the second time
-        mvc.perform(put("/csars/k8s-cluster/transformations/p-a/create"))
+        mvc.perform(put(CREATE_CSAR_VALID_URL))
             .andDo(print())
             .andExpect(status().is(400))
             .andExpect(content().bytes(new byte[0]))
             .andReturn();
     }
-
     //</editor-fold>
+    
     //<editor-fold desc="Platform Not found Tests">
     @Test
     public void newTransformationPlatformNotFound() throws Exception {
-        mvc.perform(put("/csars/k8s-cluster/transformations/p-z/create"))
+        mvc.perform(put(PLATFORM_NOT_FOUND_URL + "/create"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationInfoPlatformNotFound() throws Exception {
-        mvc.perform(get("/csars/k8s-cluster/transformations/p-z"))
+        mvc.perform(get(PLATFORM_NOT_FOUND_URL + ""))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationLogsPlatformNotFound() throws Exception {
-        mvc.perform(get("/csars/k8s-cluster/transformations/p-z/logs"))
+        mvc.perform(get(PLATFORM_NOT_FOUND_URL + "/logs"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationArtifactPlatformNotFound() throws Exception {
-        mvc.perform(get("/csars/k8s-cluster/transformations/p-z/artifacts"))
+        mvc.perform(get(PLATFORM_NOT_FOUND_URL + "/artifacts"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationPropertiesGetPlatformNotFound() throws Exception {
-        mvc.perform(get("/csars/k8s-cluster/transformations/p-z/properties"))
+        mvc.perform(get(PLATFORM_NOT_FOUND_URL + "/properties"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationPropertiesPutPlatformNotFound() throws Exception {
         mvc.perform(
-            put("/csars/k8s-cluster/transformations/p-z/properties")
+            put(PLATFORM_NOT_FOUND_URL + "/properties")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"properties\": {}}")
         ).andDo(print()).andExpect(status().isNotFound()).andReturn();
@@ -366,52 +439,58 @@ public class TransformationControllerTest extends BaseSpringTest {
 
     @Test
     public void transformationDeletePlatformNotFound() throws Exception {
-        mvc.perform(delete("/csars/k8s-cluster/transformations/p-z/delete"))
+        mvc.perform(delete(PLATFORM_NOT_FOUND_URL + "/delete"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
+    @Test
+    public void transformationStartPlatformNotFound() throws Exception {
+        mvc.perform(delete(PLATFORM_NOT_FOUND_URL + "/delete"))
+            .andDo(print()).andExpect(status().isNotFound()).andReturn();
+    }
     //</editor-fold>
+    
     //<editor-fold desc="CSAR Not found Tests">
     @Test
     public void listTransformationsCsarNotFound() throws Exception {
-        mvc.perform(get("/csars/keinechtescsar/transformations"))
+        mvc.perform(get(CSAR_NOT_FOUND_URL + ""))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void newTransformationCsarNotFound() throws Exception {
-        mvc.perform(put("/csars/keinechtescsar/transformations/p-a/create"))
+        mvc.perform(put(CSAR_NOT_FOUND_URL + "/p-a/create"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationInfoCsarNotFound() throws Exception {
-        mvc.perform(get("/csars/keinechtescsar/transformations/p-a"))
+        mvc.perform(get(CSAR_NOT_FOUND_URL + "/p-a"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationLogsCsarNotFound() throws Exception {
-        mvc.perform(get("/csars/keinechtescsar/transformations/p-a/logs"))
+        mvc.perform(get(CSAR_NOT_FOUND_URL + "/p-a/logs"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationArtifactCsarNotFound() throws Exception {
-        mvc.perform(get("/csars/keinechtescsar/transformations/p-a/artifacts"))
+        mvc.perform(get(CSAR_NOT_FOUND_URL + "/p-a/artifacts"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationPropertiesGetCsarNotFound() throws Exception {
-        mvc.perform(get("/csars/keinechtescsar/transformations/p-a/properties"))
+        mvc.perform(get(CSAR_NOT_FOUND_URL + "/p-a/properties"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
     public void transformationPropertiesPutCsarNotFound() throws Exception {
         mvc.perform(
-            put("/csars/keinechtescsar/transformations/p-a/properties")
+            put(CSAR_NOT_FOUND_URL + "/p-a/properties")
                 .content("{\"properties\": {}}")
                 .contentType(MediaType.APPLICATION_JSON)
         ).andDo(print()).andExpect(status().isNotFound()).andReturn();
@@ -419,16 +498,22 @@ public class TransformationControllerTest extends BaseSpringTest {
 
     @Test
     public void transformationDeleteCsarNotFound() throws Exception {
-        mvc.perform(delete("/csars/keinechtescsar/transformations/p-a/delete"))
+        mvc.perform(delete(CSAR_NOT_FOUND_URL + "/p-a/delete"))
             .andDo(print()).andExpect(status().isNotFound()).andReturn();
     }
 
+    @Test
+    public void transformationStartCsarNotFound() throws Exception {
+        mvc.perform(post(CSAR_NOT_FOUND_URL + "/p-a/start"))
+            .andDo(print()).andExpect(status().isNotFound()).andReturn();
+    }
     //</editor-fold>
+    
     //<editor-fold desc="Util Methods">
     public void preInitNonCreationTests() throws PlatformNotFoundException {
         //add a transformation
-        Csar csar = csarService.getCsar("k8s-cluster");
-        transformationService.createTransformation(csar, platformService.findPlatformById("p-a"));
+        Csar csar = csarService.getCsar(VALID_CSAR_NAME);
+        transformationService.createTransformation(csar, platformService.findPlatformById(VALID_PLATFORM_NAME));
         transformationService.createTransformation(csar, platformService.findPlatformById("p-b"));
     }
     //</editor-fold>

--- a/core/src/test/java/org/opentosca/toscana/core/api/upload/TOSCAnaUploadInterface.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/upload/TOSCAnaUploadInterface.java
@@ -10,9 +10,9 @@ public interface TOSCAnaUploadInterface {
     Call<ResponseBody> getStatus();
 
     @Multipart
-    @POST("csars/{name}")
+    @POST("csars/{checkStateNoPropsSet}")
     Call<ResponseBody> upload(
         @Part MultipartBody.Part body,
-        @Path("name") String name
+        @Path("checkStateNoPropsSet") String name
     );
 }

--- a/core/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
@@ -25,7 +25,7 @@ public class CsarFilesystemDaoTest extends BaseSpringTest {
 
     @Test
     public void create() throws Exception {
-        String identifier = "my-csar-name";
+        String identifier = "my-csar-checkStateNoPropsSet";
         File csarFile = TestCsars.CSAR_YAML_VALID_DOCKER_SIMPLETASK;
         InputStream csarStream = new FileInputStream(csarFile);
         csarDao.create(identifier, csarStream);

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/DummyPlatformService.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/DummyPlatformService.java
@@ -1,16 +1,15 @@
 package org.opentosca.toscana.core.dummy;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.opentosca.toscana.core.plugin.PluginService;
 import org.opentosca.toscana.core.plugin.TransformationPlugin;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyType;
-import org.opentosca.toscana.core.transformation.properties.RequirementType;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Mock Platform provider to be used in order to test Csar Controller and Transformation Controller Once integration
@@ -29,7 +28,7 @@ public class DummyPlatformService implements PluginService {
         for (int i = 0; i < 5; i++) {
             HashSet<Property> properties = new HashSet<>();
             for (PropertyType type : PropertyType.values()) {
-                properties.add(new Property(type.getTypeName() + "_property", type, RequirementType.NEVER));
+                properties.add(new Property(type.getTypeName() + "_property", type));
             }
             platforms.add(new Platform("p-" + chars[i], "platform-" + (i + 1), properties));
         }

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/DummyTransformation.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/DummyTransformation.java
@@ -19,7 +19,7 @@ public class DummyTransformation implements Transformation {
 
     public DummyTransformation(Platform platform) {
         this.platform = platform;
-        this.properties = new PropertyInstance(platform.properties);
+        this.properties = new PropertyInstance(platform.properties, this);
     }
 
     public DummyTransformation(Platform platform, TransformationState s) {

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/DummyTransformationService.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/DummyTransformationService.java
@@ -1,12 +1,15 @@
     package org.opentosca.toscana.core.dummy;
 
-    import org.opentosca.toscana.core.csar.Csar;
-    import org.opentosca.toscana.core.transformation.Transformation;
-    import org.opentosca.toscana.core.transformation.TransformationService;
-    import org.opentosca.toscana.core.transformation.platform.Platform;
+import org.opentosca.toscana.core.csar.Csar;
+import org.opentosca.toscana.core.transformation.Transformation;
+import org.opentosca.toscana.core.transformation.TransformationService;
+import org.opentosca.toscana.core.transformation.TransformationState;
+import org.opentosca.toscana.core.transformation.platform.Platform;
 
 public class DummyTransformationService implements TransformationService {
     private boolean returnValue = true;
+    
+    private boolean startReturnValue = false;
 
     @Override
     public Transformation createTransformation(Csar csar, Platform targetPlatform) {
@@ -16,13 +19,20 @@ public class DummyTransformationService implements TransformationService {
         return t;
     }
 
-    public void setReturnValue(boolean returnValue) {
+    public void setDeleteReturnValue(boolean returnValue) {
         this.returnValue = returnValue;
+    }
+
+    public void setStartReturnValue(boolean startReturnValue) {
+        this.startReturnValue = startReturnValue;
     }
 
     @Override
     public boolean startTransformation(Transformation transformation) {
-        return false;
+        if(startReturnValue) {
+            transformation.setState(TransformationState.TRANSFORMING);
+        }
+        return startReturnValue;
     }
 
     @Override

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationPropertyHandlingTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationPropertyHandlingTest.java
@@ -7,12 +7,12 @@ import org.mockito.Mock;
 
 import org.opentosca.toscana.core.BaseJUnitTest;
 import org.opentosca.toscana.core.dummy.DummyCsar;
+import org.opentosca.toscana.core.dummy.DummyLog;
 import org.opentosca.toscana.core.testutils.CategoryAwareJUnitRunner;
 import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyType;
-import org.opentosca.toscana.core.transformation.properties.RequirementType;
 
 import java.io.File;
 import java.util.HashSet;
@@ -37,14 +37,10 @@ public class TransformationPropertyHandlingTest extends BaseJUnitTest {
                 new Property(
                     "prop-" + i,
                     PropertyType.UNSIGNED_INTEGER,
-                    RequirementType.TRANSFORMATION,
                     "No real Description",
                     i < 5 //Only mark the first 5 properties as required
                 )
             );
-        }
-        for (int i = 0; i < 10; i++) {
-            props.add(new Property("prop-deploy-" + i, PropertyType.UNSIGNED_INTEGER, RequirementType.DEPLOYMENT));
         }
         Platform p = new Platform("test", "Test Platform", props);
         transformation = new TransformationImpl(csar, p, log);
@@ -76,7 +72,7 @@ public class TransformationPropertyHandlingTest extends BaseJUnitTest {
         for (int i = 0; i < 9; i++) {
             transformation.setProperty("prop-" + i, "1");
         }
-        assertFalse(transformation.allPropertiesSet(RequirementType.TRANSFORMATION));
+        assertFalse(transformation.allPropertiesSet());
     }
 
     @Test
@@ -84,7 +80,7 @@ public class TransformationPropertyHandlingTest extends BaseJUnitTest {
         for (int i = 0; i < 10; i++) {
             transformation.setProperty("prop-" + i, "1");
         }
-        assertTrue(transformation.allPropertiesSet(RequirementType.TRANSFORMATION));
+        assertTrue(transformation.allPropertiesSet());
     }
 
     @Test
@@ -92,8 +88,8 @@ public class TransformationPropertyHandlingTest extends BaseJUnitTest {
         for (int i = 0; i < 5; i++) {
             transformation.setProperty("prop-" + i, "1");
         }
-        assertTrue(transformation.allRequiredPropertiesSet(RequirementType.TRANSFORMATION));
-        assertFalse(transformation.allPropertiesSet(RequirementType.TRANSFORMATION));
+        assertTrue(transformation.allRequiredPropertiesSet());
+        assertFalse(transformation.allPropertiesSet());
     }
 
     @Test
@@ -101,17 +97,15 @@ public class TransformationPropertyHandlingTest extends BaseJUnitTest {
         for (int i = 0; i < 4; i++) {
             transformation.setProperty("prop-" + i, "1");
         }
-        assertFalse(transformation.allRequiredPropertiesSet(RequirementType.TRANSFORMATION));
-        assertFalse(transformation.allPropertiesSet(RequirementType.TRANSFORMATION));
+        assertFalse(transformation.allRequiredPropertiesSet());
+        assertFalse(transformation.allPropertiesSet());
     }
 
     @Test
     public void checkEmptyProperties() throws Exception {
         DummyCsar csar = new DummyCsar("dummy");
-        this.transformation = new TransformationImpl(csar, new Platform("test", "test", new HashSet<>()), log); 
-        for (RequirementType type : RequirementType.values()) {
-            assertTrue(transformation.allRequiredPropertiesSet(type));
-            assertTrue(transformation.allPropertiesSet(type));
-        }
+        this.transformation = new TransformationImpl(csar, new Platform("test", "test", new HashSet<>()), new DummyLog());
+        assertTrue(transformation.allRequiredPropertiesSet());
+        assertTrue(transformation.allPropertiesSet());
     }
 }

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
@@ -1,7 +1,9 @@
 package org.opentosca.toscana.core.transformation;
 
-import org.junit.Before;
-import org.junit.Test;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashSet;
+
 import org.opentosca.toscana.core.BaseSpringTest;
 import org.opentosca.toscana.core.api.exceptions.PlatformNotFoundException;
 import org.opentosca.toscana.core.csar.Csar;
@@ -14,16 +16,16 @@ import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 import org.opentosca.toscana.core.transformation.properties.Property;
 import org.opentosca.toscana.core.transformation.properties.PropertyType;
-import org.opentosca.toscana.core.transformation.properties.RequirementType;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.util.HashSet;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TransformationServiceImplTest extends BaseSpringTest {
 
@@ -68,7 +70,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         DummyCsar csar = new DummyCsar("test");
         csar.modelSpecificProperties = new HashSet<>();
         csar.modelSpecificProperties
-            .add(new Property("test", PropertyType.TEXT, RequirementType.TRANSFORMATION));
+            .add(new Property("test", PropertyType.TEXT));
         Transformation t = service.createTransformation(csar, passingDummy.getPlatform());
         assertTrue(!service.startTransformation(t));
     }
@@ -78,7 +80,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         Transformation t = service.createTransformation(csar, passingDummy.getPlatform());
         assertNotNull(csar.getTransformations().get(passingDummy.getPlatform().id));
         assertNotNull(t);
-        assertEquals(TransformationState.CREATED, t.getState());
+        assertEquals(TransformationState.READY, t.getState());
     }
 
     @Test(expected = PlatformNotFoundException.class)
@@ -91,7 +93,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
         DummyCsar csar = new DummyCsar("test");
         csar.modelSpecificProperties = new HashSet<>();
         csar.modelSpecificProperties
-            .add(new Property("test", PropertyType.TEXT, RequirementType.TRANSFORMATION));
+            .add(new Property("test", PropertyType.TEXT));
         Transformation t = service.createTransformation(csar, passingDummy.getPlatform());
         assertNotNull(csar.getTransformations().get(passingDummy.getPlatform().id));
         assertNotNull(t);

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/properties/PropertyInstanceTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/properties/PropertyInstanceTest.java
@@ -1,0 +1,78 @@
+package org.opentosca.toscana.core.transformation.properties;
+
+import java.util.HashSet;
+
+import org.opentosca.toscana.core.BaseJUnitTest;
+import org.opentosca.toscana.core.dummy.DummyTransformation;
+import org.opentosca.toscana.core.transformation.platform.Platform;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.opentosca.toscana.core.transformation.TransformationState.INPUT_REQUIRED;
+import static org.opentosca.toscana.core.transformation.TransformationState.READY;
+
+public class PropertyInstanceTest extends BaseJUnitTest {
+
+    private PropertyInstance instance;
+    private DummyTransformation transformation;
+
+    @Before
+    public void init() throws Exception {
+        HashSet<Property> properties = new HashSet<>();
+        for (int i = 0; i < 10; i++) {
+            properties.add(new Property("p-" + i, PropertyType.INTEGER, "", i < 5));
+        }
+        this.transformation = new DummyTransformation(new Platform("test", "test", properties));
+        this.instance = transformation.getProperties();
+    }
+
+    @Test
+    public void checkStateNoPropsSet() throws Exception {
+        assertEquals(INPUT_REQUIRED, this.transformation.getState());
+    }
+
+    @Test
+    public void checkStateAllRequiredPropsSet() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            assertEquals(INPUT_REQUIRED, this.transformation.getState());
+            this.instance.setPropertyValue("p-" + i, "" + i);
+        }
+        assertTrue(this.instance.allRequiredPropertiesSet());
+        assertFalse(this.instance.allPropertiesSet());
+        assertEquals(READY, this.transformation.getState());
+    }
+
+    @Test
+    public void checkAllPropsSet() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                assertEquals(INPUT_REQUIRED, this.transformation.getState());
+            } else {
+                assertEquals(READY, this.transformation.getState());
+            }
+            this.instance.setPropertyValue("p-" + i, "" + i);
+        }
+        assertTrue(this.instance.allRequiredPropertiesSet());
+        assertTrue(this.instance.allPropertiesSet());
+    }
+
+    @Test
+    public void checkSetInvalidProperty() throws Exception {
+        for (int i = 0; i < 4; i++) {
+            assertEquals(INPUT_REQUIRED, this.transformation.getState());
+            this.instance.setPropertyValue("p-" + i, "" + i);
+        }
+        try {
+            this.instance.setPropertyValue("p-4", "achd");
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace(System.out);
+        }
+        assertFalse(this.instance.allRequiredPropertiesSet());
+        assertFalse(this.instance.allPropertiesSet());
+        assertEquals(INPUT_REQUIRED, this.transformation.getState());
+    }
+}

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/properties/ValidatorTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/properties/ValidatorTest.java
@@ -3,6 +3,7 @@ package org.opentosca.toscana.core.transformation.properties;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.opentosca.toscana.core.BaseJUnitTest;
 import org.opentosca.toscana.core.transformation.properties.validators.BooleanValidator;
 import org.opentosca.toscana.core.transformation.properties.validators.FloatValidator;
 import org.opentosca.toscana.core.transformation.properties.validators.IntegerValidator;
@@ -16,7 +17,7 @@ import org.junit.runners.Parameterized;
 import static org.junit.Assert.assertSame;
 
 @RunWith(Parameterized.class)
-public class ValidatorTest {
+public class ValidatorTest extends BaseJUnitTest{
 
     private ValueValidator validator;
     private boolean accept;

--- a/core/src/test/java/org/opentosca/toscana/core/util/status/StatusServiceTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/util/status/StatusServiceTest.java
@@ -39,7 +39,7 @@ public class StatusServiceTest {
                 c.getTransformations().put("p-" + i,
                     new DummyTransformation(
                         new Platform("p", "p", new HashSet<>()),
-                        TransformationState.CREATED)
+                        TransformationState.READY)
                 );
             }
         }


### PR DESCRIPTION
This PR modifies the `/properties` response mappings for transformations in the way we discussed in the last meeting.

This means:
- `GET /properties` now also returns the current value of the property (null if it is not set). It can also be called when the transformation is not in the `INPUT_REQUIRED` state anymore.
- `PUT /properties` now returns a empty body if all sent properties have been set sucessfully
    - The original response only gets sent if at least one of the set values is invalid

The reason why this is "WIP":
- Maybe we should change the state to created once all required properties have been set. To inform the user once all required properties have been set


This PR Also resolves #109, #110 (was not much todo)