### PR TITLE
Refactor/optional return

### DIFF
--- a/core/src/main/java/org/opentosca/toscana/core/api/PlatformController.java
+++ b/core/src/main/java/org/opentosca/toscana/core/api/PlatformController.java
@@ -1,6 +1,7 @@
 package org.opentosca.toscana.core.api;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 import org.opentosca.toscana.core.api.exceptions.PlatformNotFoundException;
 import org.opentosca.toscana.core.api.model.PlatformResponse;
@@ -86,10 +87,8 @@ public class PlatformController {
     public ResponseEntity<PlatformResponse> getPlatform(
         @PathVariable(name = "id") String id
     ) {
-        Platform p = platformService.findPlatformById(id);
-        if (p == null) {
-            throw new PlatformNotFoundException();
-        }
+        Optional<Platform> optionalPlatform = platformService.findPlatformById(id);
+        Platform p = optionalPlatform.orElseThrow(PlatformNotFoundException::new);
         return ResponseEntity.ok(getPlatformResource(p));
     }
 

--- a/core/src/main/java/org/opentosca/toscana/core/api/model/ArtifactResponse.java
+++ b/core/src/main/java/org/opentosca/toscana/core/api/model/ArtifactResponse.java
@@ -9,7 +9,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 public class ArtifactResponse extends ResourceSupport {
-   
+
     private final String accessURL;
 
     public ArtifactResponse(

--- a/core/src/main/java/org/opentosca/toscana/core/csar/Csar.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/Csar.java
@@ -1,6 +1,8 @@
 package org.opentosca.toscana.core.csar;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.opentosca.toscana.core.transformation.Transformation;
@@ -18,11 +20,22 @@ public interface Csar {
     Map<String, Transformation> getTransformations();
 
     /**
+     @param platformId the target platform id which will match the the returned transformation
+     @return the transformation of this csar which match given platform
+     */
+    Optional<Transformation> getTransformation(String platformId);
+
+    /**
      @return the identifier of the CSAR
      */
     String getIdentifier();
 
-    TServiceTemplate getTemplate();
+    /**
+     @return the parsed template (wrapped in Optional) of the csar.
+     <p>
+     Empty if not parsed yet.
+     */
+    Optional<TServiceTemplate> getTemplate();
 
     /**
      Returns model specific properties as a set. If there are none a empty set has to be returned. this must not
@@ -36,4 +49,6 @@ public interface Csar {
      @return the log of this csar, which e.g. contains information about parsing
      */
     Log getLog();
+
+    void setTransformations(List<Transformation> transformations);
 }

--- a/core/src/main/java/org/opentosca/toscana/core/csar/CsarDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/CsarDao.java
@@ -3,6 +3,7 @@ package org.opentosca.toscana.core.csar;
 import java.io.File;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 public interface CsarDao {
 
@@ -22,9 +23,10 @@ public interface CsarDao {
     void delete(String identifier);
 
     /**
-     Returns a CSAR which matches given csarName, or null if no match was found.
+     Returns a optional CSAR instance which matches given csarName.
+     If no match was found, the optional contains null.
      */
-    Csar find(String identifier);
+    Optional<Csar> find(String identifier);
 
     /**
      Returns a list of all csars.

--- a/core/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.zip.ZipInputStream;
 
 import javax.annotation.PostConstruct;
@@ -106,9 +107,10 @@ public class CsarFilesystemDao implements CsarDao {
     }
 
     @Override
-    public Csar find(String identifier) {
+    public Optional<Csar> find(String identifier) {
         readFromDisk(); // TODO: change this to some smart behaviour. e.g. file watcher
-        return csarMap.get(identifier);
+        Csar csar = csarMap.get(identifier);
+        return Optional.ofNullable(csar);
     }
 
     @Override

--- a/core/src/main/java/org/opentosca/toscana/core/csar/CsarImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/CsarImpl.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.opentosca.toscana.core.transformation.Transformation;
@@ -37,13 +38,19 @@ class CsarImpl implements Csar {
     }
 
     @Override
+    public Optional<Transformation> getTransformation(String platformId) {
+        Transformation t = transformations.get(platformId);
+        return Optional.ofNullable(t);
+    }
+
+    @Override
     public String getIdentifier() {
         return identifier;
     }
 
     @Override
-    public TServiceTemplate getTemplate() {
-        return template;
+    public Optional<TServiceTemplate> getTemplate() {
+        return Optional.ofNullable(template);
     }
 
     @Override
@@ -73,6 +80,7 @@ class CsarImpl implements Csar {
             .toHashCode();
     }
 
+    @Override
     public void setTransformations(List<Transformation> transformations) {
         for (Transformation transformation : transformations) {
             this.transformations.put(transformation.getPlatform().id, transformation);

--- a/core/src/main/java/org/opentosca/toscana/core/csar/CsarService.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/CsarService.java
@@ -2,13 +2,14 @@ package org.opentosca.toscana.core.csar;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 import org.opentosca.toscana.core.parse.InvalidCsarException;
 
 public interface CsarService {
 
     /**
-     Creates a new Csar instance
+     Creates a new Csar instance.
 
      @param identifier identifying name of csar, must match [a-z0-9_-]+
      @param csarStream the actual cloud service archive as InputStream
@@ -24,12 +25,13 @@ public interface CsarService {
     void deleteCsar(Csar csar);
 
     /**
-     Returns all Csars currently managed by the application
+     Returns all Csars currently managed by the application.
      */
     List<Csar> getCsars();
 
     /**
-     Returns csar which identifier field matches given identifier. Returns null if no match is found
+     Returns an optional csar which identifier field matches given identifier.
+     Note: The optional is null, if no matching csar is found.
      */
-    Csar getCsar(String identifier);
+    Optional<Csar> getCsar(String identifier);
 }

--- a/core/src/main/java/org/opentosca/toscana/core/csar/CsarServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/csar/CsarServiceImpl.java
@@ -2,6 +2,7 @@ package org.opentosca.toscana.core.csar;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 import org.opentosca.toscana.core.parse.CsarParseService;
 import org.opentosca.toscana.core.parse.InvalidCsarException;
@@ -41,7 +42,7 @@ public class CsarServiceImpl implements CsarService {
     }
 
     private void populateWithTemplate(Csar csar) throws InvalidCsarException {
-        if (csar.getTemplate() == null) {
+        if (!csar.getTemplate().isPresent()) {
             TServiceTemplate template = csarParser.parse(csar);
             csar.setTemplate(template);
         }
@@ -67,13 +68,15 @@ public class CsarServiceImpl implements CsarService {
     }
 
     @Override
-    public Csar getCsar(String identifier) {
-        Csar csar = csarDao.find(identifier);
-        try {
-            populateWithTemplate(csar);
-        } catch (InvalidCsarException e) {
-            logger.error("Encountered invalid csar in repository.", csar, e);
-            // TODO wait for discussion outcome, maybe cleanup disk
+    public Optional<Csar> getCsar(String identifier) {
+        Optional<Csar> csar = csarDao.find(identifier);
+        if (csar.isPresent()) {
+            try {
+                populateWithTemplate(csar.get());
+            } catch (InvalidCsarException e) {
+                logger.error("Encountered invalid csar in repository.", csar, e);
+                // TODO wait for discussion outcome, maybe cleanup disk
+            }
         }
         return csar;
     }

--- a/core/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
+++ b/core/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
@@ -6,7 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.opentosca.toscana.core.transformation.Transformation;
+import org.opentosca.toscana.core.transformation.logging.Log;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -17,8 +17,8 @@ public class PluginFileAccess {
     private final File sourceDir;
     private final File targetDir;
 
-    public PluginFileAccess(Transformation transformation, File sourceDir, File targetDir) {
-        logger = transformation.getLog().getLogger(getClass());
+    public PluginFileAccess(File sourceDir, File targetDir, Log log) {
+        this.logger = log.getLogger(getClass());
         this.sourceDir = sourceDir;
         this.targetDir = targetDir;
     }

--- a/core/src/main/java/org/opentosca/toscana/core/plugin/PluginServiceImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/plugin/PluginServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.opentosca.toscana.core.transformation.platform.Platform;
@@ -44,14 +45,11 @@ public class PluginServiceImpl implements PluginService {
     }
 
     @Override
-    public Platform findPlatformById(String id) {
-        Platform p = null;
-        for (TransformationPlugin plugin : plugins) {
-            if (id.equals(plugin.getPlatform().id)) {
-                p = plugin.getPlatform();
-            }
-        }
-        return p;
+    public Optional<Platform> findPlatformById(String id) {
+        return plugins.stream()
+            .filter(plugin -> plugin.getPlatform().id.equals(id))
+            .map(transformationPlugin -> transformationPlugin.getPlatform())
+            .findFirst();
     }
 
     @Override

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationContext.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationContext.java
@@ -3,34 +3,40 @@ package org.opentosca.toscana.core.transformation;
 import java.io.File;
 
 import org.opentosca.toscana.core.plugin.PluginFileAccess;
+import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.properties.PropertyInstance;
 
 import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.slf4j.Logger;
 
 public final class TransformationContext {
-    private final Transformation transformation;
-    private final PluginFileAccess access;
 
-    public TransformationContext(Transformation transformation, File csarContentDir, File transformationRootDir) {
-        this.transformation = transformation;
-        this.access = new PluginFileAccess(transformation, csarContentDir, transformationRootDir);
+    private final Log log;
+    private final PluginFileAccess access;
+    private final TServiceTemplate template;
+    private final PropertyInstance properties;
+
+    public TransformationContext(File csarContentDir, File transformationRootDir, Log log, TServiceTemplate template, PropertyInstance properties) {
+        this.log = log;
+        this.template = template;
+        this.properties = properties;
+        this.access = new PluginFileAccess(csarContentDir, transformationRootDir, log);
     }
 
     public TServiceTemplate getServiceTemplate() {
-        return transformation.getCsar().getTemplate();
+        return template;
     }
 
     public PropertyInstance getProperties() {
-        return transformation.getProperties();
+        return properties;
     }
 
     public Logger getLogger(String context) {
-        return transformation.getLog().getLogger(context);
+        return log.getLogger(context);
     }
 
     public Logger getLogger(Class clazz) {
-        return transformation.getLog().getLogger(clazz);
+        return log.getLogger(clazz);
     }
 
     public PluginFileAccess getPluginFileAccess() {

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
@@ -83,9 +83,10 @@ public class TransformationFilesystemDao implements TransformationDao {
             if (!pluginEntry.isDirectory()) {
                 continue;
             }
-            Platform platform = platformService.findPlatformById(pluginEntry.getName());
-            if (platform != null) {
-                Transformation transformation = new TransformationImpl(csar, platform, getLog(csar, platform));
+            Optional<Platform> platform = platformService.findPlatformById(pluginEntry.getName());
+            if (platform.isPresent()) {
+                Log log = getLog(csar, platform.get());
+                Transformation transformation = new TransformationImpl(csar, platform.get(), log);
                 // TODO set transformation state
                 transformations.add(transformation);
             } else {

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
@@ -12,7 +12,7 @@ import org.opentosca.toscana.core.transformation.properties.PropertyInstance;
 
 import static java.lang.String.format;
 
-class TransformationImpl implements Transformation {
+public class TransformationImpl implements Transformation {
 
     private final Csar csar;
     private final Platform targetPlatform;
@@ -27,7 +27,7 @@ class TransformationImpl implements Transformation {
      @param csar           the subject of transformation
      @param targetPlatform the target platform
      */
-    TransformationImpl(Csar csar, Platform targetPlatform, Log log) {
+    public TransformationImpl(Csar csar, Platform targetPlatform, Log log) {
         this.csar = csar;
         this.targetPlatform = targetPlatform;
         this.log = log;

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/execution/ExecutionTask.java
@@ -11,6 +11,7 @@ import org.opentosca.toscana.core.transformation.TransformationState;
 import org.opentosca.toscana.core.transformation.artifacts.ArtifactService;
 import org.opentosca.toscana.core.transformation.artifacts.TargetArtifact;
 
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.slf4j.Logger;
 
 public class ExecutionTask implements Runnable {
@@ -72,7 +73,10 @@ public class ExecutionTask implements Runnable {
 
     private void transform() {
         try {
-            plugin.transform(new TransformationContext(transformation, csarContentDir, transformationRootDir));
+            TServiceTemplate template = transformation.getCsar().getTemplate().orElseThrow(() ->
+                new IllegalStateException("TServiceTemplate is null, will not start transformation."));
+            plugin.transform(new TransformationContext(csarContentDir, transformationRootDir,
+                transformation.getLog(), template, transformation.getProperties()));
             transformation.setState(TransformationState.DONE);
         } catch (Exception e) {
             log.info("Transformation of {}/{} failed", csarId, platformId);

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/platform/PlatformService.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/platform/PlatformService.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.core.transformation.platform;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -15,9 +16,9 @@ public interface PlatformService {
      Finds a specific platform by its identifier
 
      @param id the id to look for
-     @return the resulting platform object, null if the platform does not exist
+     @return the resulting platform object wrapped in an optional - is empty if no match was found
      */
-    Platform findPlatformById(String id);
+    Optional<Platform> findPlatformById(String id);
 
     boolean isSupported(Platform platform);
 }

--- a/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/ArtifactControllerTest.java
@@ -34,7 +34,7 @@ public class ArtifactControllerTest extends BaseSpringTest {
     private final static int size = 20 * 1024;
     private final static int count = 5;
     private final static byte[][] hashes = new byte[count][];
-    
+
     private MockMvc mvc;
     private ArtifactController controller;
     private MessageDigest digest;

--- a/core/src/test/java/org/opentosca/toscana/core/api/CsarControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/CsarControllerTest.java
@@ -91,9 +91,10 @@ public class CsarControllerTest extends BaseSpringTest {
         ).andDo(print()).andExpect(status().is2xxSuccessful());
         resultActions.andReturn();
 
+        DummyCsar dummyCsar = (DummyCsar) service.getCsar("rnd").get();
         byte[] hashUpload = MessageDigest
             .getInstance("SHA-256")
-            .digest(((DummyCsar) service.getCsar("rnd")).getData());
+            .digest(dummyCsar.getData());
         assertTrue(hashUpload.length == hash.length);
         for (int i = 0; i < hash.length; i++) {
             assertTrue(hash[i] == hashUpload[i]);

--- a/core/src/test/java/org/opentosca/toscana/core/api/mocks/MockCsarService.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/mocks/MockCsarService.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.opentosca.toscana.core.api.utils.StreamUtils;
 import org.opentosca.toscana.core.csar.Csar;
@@ -25,7 +26,7 @@ public class MockCsarService implements CsarService {
 
     @Override
     public Csar submitCsar(String name, InputStream csarStream) {
-        if (getCsar(name) != null) {
+        if (getCsar(name).isPresent()) {
             return null;
         }
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -52,12 +53,12 @@ public class MockCsarService implements CsarService {
     }
 
     @Override
-    public Csar getCsar(String identifier) {
+    public Optional<Csar> getCsar(String identifier) {
         for (Csar csar : csars) {
             if (csar.getIdentifier().equals(identifier)) {
-                return csar;
+                return Optional.of(csar);
             }
         }
-        return null;
+        return Optional.ofNullable(null);
     }
 }

--- a/core/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 import org.opentosca.toscana.core.BaseSpringTest;
 import org.opentosca.toscana.core.testdata.TestCsars;
@@ -16,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class CsarFilesystemDaoTest extends BaseSpringTest {
@@ -51,9 +51,9 @@ public class CsarFilesystemDaoTest extends BaseSpringTest {
     @Test
     public void find() throws Exception {
         String identifier = createFakeCsarDirectories(1)[0];
-        Csar csar = csarDao.find(identifier);
-        assertNotNull(csar);
-        assertEquals(identifier, csar.getIdentifier());
+        Optional<Csar> csar = csarDao.find(identifier);
+        assertTrue(csar.isPresent());
+        assertEquals(identifier, csar.get().getIdentifier());
     }
 
     @Test
@@ -64,9 +64,10 @@ public class CsarFilesystemDaoTest extends BaseSpringTest {
         File transformationsDir = new File(csarDir, "transformations");
         TestPlugins.createFakeTransformationsOnDisk(transformationsDir, TestPlugins.PLATFORMS);
 
-        Csar csar = csarDao.find(identifier);
+        Optional<Csar> csar = csarDao.find(identifier);
 
-        assertEquals(TestPlugins.PLATFORMS.size(), csar.getTransformations().size());
+        assertTrue(csar.isPresent());
+        assertEquals(TestPlugins.PLATFORMS.size(), csar.get().getTransformations().size());
     }
 
     @Test

--- a/core/src/test/java/org/opentosca/toscana/core/csar/CsarImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/csar/CsarImplTest.java
@@ -1,0 +1,51 @@
+package org.opentosca.toscana.core.csar;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.opentosca.toscana.core.BaseJUnitTest;
+import org.opentosca.toscana.core.transformation.Transformation;
+import org.opentosca.toscana.core.transformation.logging.Log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.opentosca.toscana.core.testdata.TestPlugins.PLATFORM1;
+import static org.opentosca.toscana.core.testdata.TestPlugins.PLATFORM2;
+
+public class CsarImplTest extends BaseJUnitTest {
+
+    private Csar csar;
+    @Mock
+    private Log log;
+    @Mock
+    private Transformation transformation1;
+    @Mock
+    private Transformation transformation2;
+
+    private List<Transformation> transformations = new ArrayList<>();
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        csar = new CsarImpl("csarIdentifier", log);
+        transformations.add(transformation1);
+        transformations.add(transformation2);
+        when(transformation1.getPlatform()).thenReturn(PLATFORM1);
+        when(transformation2.getPlatform()).thenReturn(PLATFORM2);
+        csar.setTransformations(transformations);
+    }
+
+    @Test
+    public void getTransformationsForSpecificPlatform() throws Exception {
+        Optional<Transformation> result = csar.getTransformation(PLATFORM1.id);
+        assertTrue(result.isPresent());
+        assertEquals(transformation1, result.get());
+    }
+}

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/DummyCsar.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/DummyCsar.java
@@ -2,7 +2,9 @@ package org.opentosca.toscana.core.dummy;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.opentosca.toscana.core.csar.Csar;
@@ -15,7 +17,7 @@ import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 public class DummyCsar implements Csar {
 
     public Set<Property> modelSpecificProperties = new HashSet<>();
-    
+
     private final String name;
     private byte[] data;
 
@@ -31,13 +33,18 @@ public class DummyCsar implements Csar {
     }
 
     @Override
+    public Optional<Transformation> getTransformation(String platformId) {
+        return Optional.ofNullable(transformations.get(platformId));
+    }
+
+    @Override
     public String getIdentifier() {
         return name;
     }
 
     @Override
-    public TServiceTemplate getTemplate() {
-        return null;
+    public Optional<TServiceTemplate> getTemplate() {
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -47,12 +54,17 @@ public class DummyCsar implements Csar {
 
     @Override
     public void setTemplate(TServiceTemplate template) {
-        //noop
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Log getLog() {
-        return null;
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTransformations(List<Transformation> transformations) {
+        throw new UnsupportedOperationException();
     }
 
     public byte[] getData() {

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/DummyCsarService.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/DummyCsarService.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.csar.CsarService;
@@ -67,7 +68,7 @@ public class DummyCsarService implements CsarService {
     }
 
     @Override
-    public Csar getCsar(String identifier) {
+    public Optional<Csar> getCsar(String identifier) {
         Csar csar = null;
         Collection<Csar> csars = getCsars();
         for (Csar c : csars) {
@@ -76,6 +77,6 @@ public class DummyCsarService implements CsarService {
                 break;
             }
         }
-        return csar;
+        return Optional.ofNullable(csar);
     }
 }

--- a/core/src/test/java/org/opentosca/toscana/core/dummy/DummyPlatformService.java
+++ b/core/src/test/java/org/opentosca/toscana/core/dummy/DummyPlatformService.java
@@ -3,6 +3,7 @@ package org.opentosca.toscana.core.dummy;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.opentosca.toscana.core.plugin.PluginService;
@@ -47,13 +48,10 @@ public class DummyPlatformService implements PluginService {
     }
 
     @Override
-    public Platform findPlatformById(String id) {
-        for (Platform platform : getSupportedPlatforms()) {
-            if (platform.id.equals(id)) {
-                return platform;
-            }
-        }
-        return null;
+    public Optional<Platform> findPlatformById(String id) {
+        return getSupportedPlatforms().stream()
+            .filter(platform -> platform.id.equals(id))
+            .findFirst();
     }
 
     @Override

--- a/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
@@ -53,7 +53,7 @@ public class PluginFileAccessTest extends BaseSpringTest {
         transformation = transformationService.createTransformation(csar, TestPlugins.PLATFORM1);
         TestPlugins.createFakeTransformationsOnDisk(csarDao.getTransformationsDir(csar), TestPlugins.PLATFORMS);
         transformationRootDir = transformationDao.getRootDir(transformation);
-        access = new PluginFileAccess(transformation, csarDao.getContentDir(csar), transformationDao.getRootDir(transformation));
+        access = new PluginFileAccess(csarDao.getContentDir(csar), transformationDao.getRootDir(transformation), transformation.getLog());
         fileContent = "this is a test content";
         inputStream = IOUtils.toInputStream(fileContent, "UTF-8");
         targetFilePath = "testFile";

--- a/core/src/test/java/org/opentosca/toscana/core/testdata/TestCsars.java
+++ b/core/src/test/java/org/opentosca/toscana/core/testdata/TestCsars.java
@@ -7,7 +7,10 @@ import java.io.FileNotFoundException;
 import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.csar.CsarDao;
 
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.mockito.Mockito.mock;
 
 /**
  Supplies test classes with csars.
@@ -48,6 +51,8 @@ public class TestCsars {
      @return instance of csar
      */
     public Csar getCsar(String identifier, File file) throws FileNotFoundException {
-        return csarDao.create(identifier, new FileInputStream(file));
+        Csar csar = csarDao.create(identifier, new FileInputStream(file));
+        csar.setTemplate(mock(TServiceTemplate.class));
+        return csar;
     }
 }

--- a/core/src/test/java/org/opentosca/toscana/core/testdata/TestTransformationContext.java
+++ b/core/src/test/java/org/opentosca/toscana/core/testdata/TestTransformationContext.java
@@ -15,12 +15,14 @@ import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.TransformationContext;
 import org.opentosca.toscana.core.transformation.TransformationDao;
 import org.opentosca.toscana.core.transformation.TransformationService;
+import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.platform.Platform;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 /**
  Supplies valid TransformationContext objects for plugin integration tests. <br> Note: Internally, uses core
@@ -49,7 +51,8 @@ public class TestTransformationContext extends BaseSpringTest {
 
         File csarContentRoot = csarDao.getContentDir(csar);
         File transformationRoot = transformationDao.getRootDir(transformation);
-        return new TransformationContext(transformation, csarContentRoot, transformationRoot);
+        return new TransformationContext(csarContentRoot, transformationRoot, mock(Log.class),
+            csar.getTemplate().get(), transformation.getProperties());
     }
 
     @Test


### PR DESCRIPTION
After screening how the api controllers have to handle calls to the service layer, I've wanted to change the service layers to always return the value wrapped in Optionals (java 8 feature) in case this value might be null. After the change, the api layer looks way cleaner.
I believe the usage of Optional will help us build more stable software.

Change:
- `csarService.getCsar(String): Csar` --> `csarService.getCsar(String): Optional<Csar>`
- `platformService.FindPlatformById(String): Platform` --> `platformService.FindPlatformById(String): Optional<Platform>`
- `csar.getTemplate()`: TServiceTemplate` --> `csar.getTemplate(): Optional<TServiceTemplate>`

Add:
- `csar.getTranformation(Platform): Optional<Transformation>`