### PR TITLE
Enhance Jenkinsfile with deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 pipeline {
     agent any
+
     stages {
         stage('Build') {
             steps {
@@ -7,45 +8,51 @@ pipeline {
                 archiveArtifacts(onlyIfSuccessful: true, artifacts: 'core/target/*.jar')
             }
         }
-        stage('Test') {
-            parallel {
-                stage('Test (Fast Tests)') {
-                    environment {
-                        TEST_MODE = 'fast'
-                    }
-                    steps {
-                        sh 'export DATADIR=$(pwd)/toscana-data && rm -r -f $(pwd)/toscana-data && mkdir $(pwd)/toscana-data && mvn test -pl core'
-                    }
-                    post {
-                        always {
-                            junit(testResults: '**/target/surefire-reports/*.xml', allowEmptyResults: true)
-                            sh 'cd core/target/site && zip -r coverage-core-fast.zip jacoco && cd ../../../; exit 0'
-                            sh 'cd cli/target/site && zip -r coverage-cli-fast.zip jacoco && cd ../../../; exit 0'
-                            archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/site/*.zip'
-                        }
-                    }
+        stage('Test') { 
+            parallel { 
+                stage('Test (Fast Tests)') { 
+                    environment { 
+                        TEST_MODE = 'fast' 
+                    } 
+                    steps { 
+                        sh 'export DATADIR=$(pwd)/toscana-data && rm -rf $(pwd)/toscana-data && mkdir $(pwd)/toscana-data && mvn test -B' 
+                    } 
+                    post { 
+                        always { 
+                            junit(testResults: '**/target/surefire-reports/*.xml', allowEmptyResults: true) 
+                            sh '[ -d core/target/site ] && cd core/target/site && zip -r coverage-core-fast.zip jacoco && cd -; exit 0' 
+                            sh '[ -d core/target/site ] && cd cli/target/site && zip -r coverage-cli-fast.zip jacoco && cd -; exit 0' 
+                            archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/site/*.zip' 
+                        } 
+                    } 
+                } 
+                stage('Test (Slow Tests)') { 
+                    environment { 
+                        TEST_MODE = 'slow' 
+                    } 
+                    steps { 
+                        sh 'export DATADIR=$(pwd)/toscana-data2 && rm -rf $(pwd)/toscana-data2 && mkdir $(pwd)/toscana-data2 && mvn test -B' 
+                    } 
+                    post { 
+                        always { 
+                            junit(testResults: 'core/target/surefire-reports/*.xml', allowEmptyResults: true) 
+                            sh '[ -d core/target/site ] && cd core/target/site && zip -r coverage-core-slow.zip jacoco && cd -; exit 0' 
+                            archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/site/*.zip' 
+                        } 
+                    } 
                 }
-                stage('Test (Slow Tests)') {
-                    environment {
-                        TEST_MODE = 'slow'
-                    }
-                    steps {
-                        sh 'export DATADIR=$(pwd)/toscana-data2 && rm -r -f $(pwd)/toscana-data2 && mkdir $(pwd)/toscana-data2 && mvn test -pl core'
-                    }
-                    post {
-                        always {
-                            junit(testResults: 'core/target/surefire-reports/*.xml', allowEmptyResults: true)
-                            sh 'cd core/target/site && zip -r coverage-core-slow.zip jacoco && cd ../../../; exit 0'
-                            archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/site/*.zip'
-                        }
-                    }
-                }
+            }
+        } 
+        stage('Deploy') {
+            steps {
+//  the JENKINS_NODE_COOKIE variable must be set to a different value than the id of this jenkins build in order for subprocesses to live longer than the build process
+                 sh 'JENKINS_NODE_COOKIE=dontKillMe toscanad' 
             }
         }
-        stage('Cleanup') {
-            steps {
-                sh 'mvn clean'
-            }
+    }
+    post {
+        always {
+            sh 'mvn clean'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                         TEST_MODE = 'fast' 
                     } 
                     steps { 
-                        sh 'export DATADIR=$(pwd)/toscana-data && rm -rf $(pwd)/toscana-data && mkdir $(pwd)/toscana-data && mvn test -B' 
+                        sh 'export DATADIR=$(pwd)/toscana-data && rm -rf $(pwd)/toscana-data && mkdir $(pwd)/toscana-data && mvn surefire:test -B' 
                     } 
                     post { 
                         always { 
@@ -31,7 +31,7 @@ pipeline {
                         TEST_MODE = 'slow' 
                     } 
                     steps { 
-                        sh 'export DATADIR=$(pwd)/toscana-data2 && rm -rf $(pwd)/toscana-data2 && mkdir $(pwd)/toscana-data2 && mvn test -B' 
+                        sh 'export DATADIR=$(pwd)/toscana-data2 && rm -rf $(pwd)/toscana-data2 && mkdir $(pwd)/toscana-data2 && mvn surefire:test -B' 
                     } 
                     post { 
                         always { 
@@ -44,6 +44,7 @@ pipeline {
             }
         } 
         stage('Deploy') {
+            agent { label 'deploy' }
             steps {
 //  the JENKINS_NODE_COOKIE variable must be set to a different value than the id of this jenkins build in order for subprocesses to live longer than the build process
                  sh 'JENKINS_NODE_COOKIE=dontKillMe toscanad' 


### PR DESCRIPTION
- clean will now always be performed (not as stage)
- when build and tests pass, the toscana server gets deployed.
  - endpoint is https://toscana.ddnss.org/api
  - a running instance gets killed before
  - each time the data dir will get a reset

As soon as this got merged into master, I will configure jenkins to build and deploy whenever there's a new commit on master.