### PR TITLE
Fix Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,9 @@ pipeline {
             }
         } 
         stage('Deploy') {
-            agent { label 'deploy' }
+            when {
+                environment name: 'TOSCANA_DEPLOY_ON_BUILD', value: 'true'
+            }
             steps {
 //  the JENKINS_NODE_COOKIE variable must be set to a different value than the id of this jenkins build in order for subprocesses to live longer than the build process
                  sh 'JENKINS_NODE_COOKIE=dontKillMe toscanad' 


### PR DESCRIPTION
The Deploy stage now only gets executed if a environment variable `TOSCANA_DEPLOY_ON_BUILD` is set to `true`. Otherwise this stage should be skipped. This change is necessary to let the build pass even if you do not want to deploy. The current approach with the label is okay, but jenkins will not finish the build if there is no Node with the label "deploy". Because it waits for a worker to appear with this label.