### PR TITLE
Refactor/despringify tests

### DIFF
--- a/core/src/main/java/org/opentosca/toscana/core/api/dev/HttpLogger.java
+++ b/core/src/main/java/org/opentosca/toscana/core/api/dev/HttpLogger.java
@@ -29,11 +29,11 @@ public class HttpLogger implements TraceRepository {
         String method = (String) traceInfo.get("method");
         String path = (String) traceInfo.get("path");
         String timeTaken = (String) traceInfo.get("timeTaken");
-        Map<String, Map<String,String>> headerMap = (Map<String, Map<String, String>>) traceInfo.get("headers");
+        Map<String, Map<String, String>> headerMap = (Map<String, Map<String, String>>) traceInfo.get("headers");
 //        Map<String, String> requestMap = headerMap.get("request");
         Map<String, String> responseMap = headerMap.get("response");
         String responseStatus = responseMap.get("status");
-        LOG.info("Request: \"{} {}\", response: {} after {}ms", method, path, responseStatus,timeTaken);
+        LOG.info("Request: \"{} {}\", response: {} after {}ms", method, path, responseStatus, timeTaken);
         this.delegate.add(traceInfo);
     }
 }

--- a/core/src/main/java/org/opentosca/toscana/core/transformation/logging/Log.java
+++ b/core/src/main/java/org/opentosca/toscana/core/transformation/logging/Log.java
@@ -2,7 +2,7 @@ package org.opentosca.toscana.core.transformation.logging;
 
 import java.util.List;
 
-import ch.qos.logback.classic.Logger;
+import org.slf4j.Logger;
 
 public interface Log {
     /**

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
     <logger name="springfox.documentation" level="WARN"/>
     <logger name="com.jayway.jsonpath" level="WARN"/>
 
-    
+
     <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/core/src/test/java/org/opentosca/toscana/core/api/CsarControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/CsarControllerTest.java
@@ -185,7 +185,7 @@ public class CsarControllerTest extends BaseSpringTest {
     @Test
     public void testDelete() throws Exception {
         //Mechanism to set this value to true once delete has been called
-        final boolean[] executed = new boolean[] {false};
+        final boolean[] executed = new boolean[]{false};
         doAnswer(iom -> executed[0] = true).when(service).deleteCsar(any(Csar.class));
         //Perform request
         mvc.perform(

--- a/core/src/test/java/org/opentosca/toscana/core/api/TransformationControllerTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/api/TransformationControllerTest.java
@@ -61,7 +61,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class TransformationControllerTest extends BaseSpringTest {
 
     //<editor-fold desc="Constant Definition">
-    
+
     private final static String VALID_PROPERTY_INPUT = "{\n" +
         "\t\"properties\": {\n" +
         "\t\t\"text_property\":\"Hallo Welt\",\n" +
@@ -94,7 +94,7 @@ public class TransformationControllerTest extends BaseSpringTest {
     private final static String CREATE_CSAR_VALID_URL = "/api/csars/k8s-cluster/transformations/p-a/create";
     private final static String PLATFORM_NOT_FOUND_URL = "/api/csars/k8s-cluster/transformations/p-z";
     private final static String CSAR_NOT_FOUND_URL = "/api/csars/keinechtescsar/transformations";
-    private static final String[] CSAR_NAMES = new String[] {"k8s-cluster", "apache-test", "mongo-db"};
+    private static final String[] CSAR_NAMES = new String[]{"k8s-cluster", "apache-test", "mongo-db"};
     private static final String SECOND_VALID_PLATFORM_NAME = "p-b";
     //</editor-fold>
 
@@ -104,7 +104,7 @@ public class TransformationControllerTest extends BaseSpringTest {
     private MockMvc mvc;
 
     //<editor-fold desc="Initialization">
-    
+
     @Before
     public void setUp() throws Exception {
         //Create Objects
@@ -161,7 +161,7 @@ public class TransformationControllerTest extends BaseSpringTest {
         });
     }
     //</editor-fold>
-    
+
     //<editor-fold desc="Start transformation tests">
 
     @Test

--- a/core/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.opentosca.toscana.core.BaseJUnitTest;
-import org.opentosca.toscana.core.BaseSpringTest;
 import org.opentosca.toscana.core.testdata.TestCsars;
 import org.opentosca.toscana.core.testdata.TestPlugins;
 import org.opentosca.toscana.core.transformation.Transformation;
@@ -22,7 +21,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -41,9 +39,9 @@ public class CsarFilesystemDaoTest extends BaseJUnitTest {
     private Preferences preferences;
     @Mock
     private Log fakeLog;
-    
+
     @Before
-    public void setUp(){
+    public void setUp() {
         preferences = mock(Preferences.class);
         when(preferences.getDataDir()).thenReturn(tmpdir);
         transformationDao = mock(TransformationDao.class);

--- a/core/src/test/java/org/opentosca/toscana/core/testdata/TestCsars.java
+++ b/core/src/test/java/org/opentosca/toscana/core/testdata/TestCsars.java
@@ -6,8 +6,6 @@ import java.io.FileNotFoundException;
 
 import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.csar.CsarDao;
-import org.opentosca.toscana.core.csar.CsarImpl;
-import org.opentosca.toscana.core.transformation.logging.Log;
 
 import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +28,7 @@ public class TestCsars {
     public final static File CSAR_YAML_INVALID_DOCKERAPP_MISSING = new File(YAML_DIR, "invalid/dockerapp_missing.csar");
     public final static File CSAR_YAML_INVALID_ENTRYPOINT_MISSING = new File(YAML_DIR, "invalid/entrypoint_missing.csar");
     public final static File CSAR_YAML_INVALID_ENTRYPOINT_AMBIGUOUS = new File(YAML_DIR, "invalid/entrypoint_ambiguous.csar");
-    
+
     @Autowired
     private CsarDao csarDao;
 

--- a/core/src/test/java/org/opentosca/toscana/core/testdata/TestTransformationContext.java
+++ b/core/src/test/java/org/opentosca/toscana/core/testdata/TestTransformationContext.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 /**
  Supplies valid TransformationContext objects for plugin integration tests. <br> Note: Internally, uses core
  functionality. Do <b>NOT</b> use this for isolated testing.
+ Try to build unit tests instead. Use this only as a last resort.
  */
 public class TestTransformationContext extends BaseSpringTest {
 

--- a/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/transformation/TransformationServiceImplTest.java
@@ -37,10 +37,10 @@ import static org.opentosca.toscana.core.testdata.TestPlugins.PLATFORM_NOT_SUPPO
 import static org.opentosca.toscana.core.testdata.TestPlugins.PLATFORM_PASSING_DUMMY;
 
 public class TransformationServiceImplTest extends BaseSpringTest {
-    
+
     private static final int WAIT_DELAY_MS = 100;
     private static final int TEST_EXECUTION_TIMEOUT_MS = 10000;
-    
+
     private static final Logger logger = LoggerFactory.getLogger(TransformationServiceImplTest.class);
     @Autowired
     private TransformationService service;
@@ -48,7 +48,7 @@ public class TransformationServiceImplTest extends BaseSpringTest {
     private TestCsars testCsars;
     @Mock
     private Log log;
-    
+
     private Csar csar;
 
     @Before

--- a/core/src/test/java/org/opentosca/toscana/core/util/health/TransformerHealthIndicatorTest.java
+++ b/core/src/test/java/org/opentosca/toscana/core/util/health/TransformerHealthIndicatorTest.java
@@ -45,7 +45,7 @@ public class TransformerHealthIndicatorTest extends BaseJUnitTest {
     //Mock data to generate the transformations 
     //First index represents the platform
     //second index represents the Current transformation state
-    private static final Object[][] MOCK_DATA = new Object[][] {
+    private static final Object[][] MOCK_DATA = new Object[][]{
         {PLATFORM1, TRANSFORMING},
         {PLATFORM2, ERROR}
     };


### PR DESCRIPTION
Aim of this PR is to make more Tests pure Unit Tests.
- CsarServiceImplTest and PluginFileAccessTest are now unit tests
- I tried to make TransformationServiceImplTest and CsarParseServiceTest pure unit tests, but I couldn't do it. I guess they will stay as they are.