### PR TITLE
Add skeleton for an architectural decision log

### DIFF
--- a/docs/adr/0000-use-markdown-architectural-decision-records.md
+++ b/docs/adr/0000-use-markdown-architectural-decision-records.md
@@ -1,0 +1,23 @@
+# Use Markdown Architectural Decision Records
+
+Should we record the architectural decisions made in this project?
+And if we do, wow to structure these recordings?
+
+## Considered Alternatives
+
+* [MADR](https://adr.github.io/madr/) - Markdown Architectural Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) - The first incarnation of the term "ADR". Maintainable by [adr-tools](https://github.com/npryce/adr-tools).
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) - The Y-Statements
+* [DecisionRecord](https://github.com/schubmat/DecisionCapture) - Agile records by [@schubmat](https://github.com/schubmat/)
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* No records
+
+## Decision Outcome
+
+* Chosen Alternative: MADR
+* Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions later on.
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+* The MADR template is lean and fits our development style.
+
+<!-- Pros and cons of alternatives straight-forward to elicit and therefore not captured. -->

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,13 @@
+# Architectural Decision Log
+
+This log lists the architectural decisions for *[project name]*.
+
+<!-- adrlog -->
+
+- [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+
+<!-- adrlogstop -->
+
+For new ADRs, please use [template.md](template.md) as basis.
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,42 @@
+# *[short title of solved problem and solution]*
+
+**User Story:** *[ticket/issue-number]* <!-- optional -->
+
+*[context and problem statement]*
+*[decision drivers | forces]* <!-- optional -->
+
+## Considered Alternatives
+
+* *[alternative 1]*
+* *[alternative 2]*
+* *[alternative 3]*
+* *[...]* <!-- numbers of alternatives can vary -->
+
+## Decision Outcome
+
+* Chosen Alternative: *[alternative 1]*
+* *[justification. e.g., only alternative, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)]*
+* *[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]* <!-- optional -->
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### *[alternative 1]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 2]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 3]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->


### PR DESCRIPTION
Since there is much discussion is going on at #56 and no one did add MADR by himself to document ADRs, this PR is the PR to add a starting point for [architectural decision records](http://adr.github.io/).