### PR TITLE
Implement Docker Base Image Mapper

### DIFF
--- a/docs/dev/plugins/kubernetes/dockerfile-mapping/base-image-mapper.md
+++ b/docs/dev/plugins/kubernetes/dockerfile-mapping/base-image-mapper.md
@@ -1,0 +1,53 @@
+# The Base Image Mapper
+
+## The Problem
+
+When Trying to convert TOSCA topologies to Docker images you have to find out on what these images should be based on. I.e. you have to find a Docker base image that will probably allow the creation of the Docker image.
+
+What we try to do is Mapping this:
+```yaml
+- os:
+    type: linux
+    distribution: ubuntu
+    version: 16.04
+    architecture: x86_64
+```
+
+to a docker base image like the `library/ubuntu` one.
+
+According to the TOSCA Specification, none of these values is required. The BaseImageMapper will try to find the best fitting base image. If possible.
+
+## Solution approach
+
+Before mapping can even start, we have to get the latest information about the Docker base image from Docker Hub (and later maybe other registries).
+When the application launches the BaseImageMapper trys to retrieve a list of all tags for the supported docker base images.
+The BaseImageMapper will support the following base images in the first revision:
+- `ubuntu`
+- `debian`
+- `alpine`
+- `centos`
+- `opensuse`
+- `busybox`
+
+On launch the application will download the latest tags from DockerHub.
+Once this process is done the Downloaded tag list will be stored in memory.
+update of the Mappings will be performed every 24 hours (will be a changeable property).
+The Key to change this value using Spring properties is `toscana.docker.base-image-mapper.update-interval`
+
+The Mapping works as follows:
+1. The mapper checks if the given capability is empty (all optionals do not conatin a value). If thats the case, it returns the default image (`library/ubuntu:latest`, the latest Ubuntu LTS version (currently 16.04))
+2. The type attribute of the Capability gets checked. If the value is not set or is `linux` the mapping will continue and fail otherwise.
+3. The distribution value is checked.
+  - If it does not match one of the Oses described above, the mapping fails.
+  - If the field is empty the image defaults to `library/ubuntu:latest`
+4. The mapping will proceed with the version check if none of the conditions described above are triggered.
+  - If no version is set `latest` will be used.
+  - If the version can be directly mapped to a tag (identical name) it will use the found tag
+  - if the version is not directly found a attempt to detect a viable tag is performed using Semantic versioning. This is done as follows. The list of tags first gets sorted by their mayor (has to be equal) and minor (has to be greater or equal) version. Everything thats smaller than the version given by the capability is not considered a version candidate and gets ignoresd.
+    - If the resulting list only contains 1 element. This element is returned as the mapped base image
+    - If the resulting list is empty, the mapping will fail (No possible images found)
+    - If multiple ones are found, the mapper will return the image that has the latest bugfix version of the minor version thats the closest to the one given in the capability.
+5. Check the architecture. if its not supported by the found tag (a invalid one is given) the mapping will fail, if its empty `amd64` will be used and the specified one afterwards.
+6. Return the resulting base image. 
+
+If a mapping fails, the `mapToBaseImage()` method throws a `UnsupportedOperationException`

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -24,27 +24,49 @@
     </repositories>
 
     <dependencies>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.11.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-client</artifactId>
-            <version>2.6.2</version>
-        </dependency>
+        <!--Project Lombok-->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.18</version>
         </dependency>
+        <!--JGraphT-->
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
             <version>1.1.0</version>
         </dependency>
+        
+        <!--Kubernetes Plugin-->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <version>2.6.2</version>
+        </dependency>
+        <!--Base Image Mapper-->
+        <!--Retrofit (Used to access the docker Registry API)-->
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-jackson</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <!--Semantic Versioning Library-->
+        <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        
         <!-- Winery -->
         <dependency>
             <groupId>com.github.stupro-toscana.winery</groupId>
@@ -62,11 +84,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-hateoas</artifactId>
         </dependency>
-        <!--This is not needed. Can probably get removed-->
-        <!--<dependency>-->
-        <!--<groupId>org.springframework.boot</groupId>-->
-        <!--<artifactId>spring-boot-starter-data-rest</artifactId>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -103,6 +120,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
         <!--Retrofit + bindings-->

--- a/server/src/main/java/org/opentosca/toscana/core/Profiles.java
+++ b/server/src/main/java/org/opentosca/toscana/core/Profiles.java
@@ -1,0 +1,6 @@
+package org.opentosca.toscana.core;
+
+public class Profiles {
+    public static final String EXCLUDE_BASE_IMAGE_MAPPER
+        = "no-default-base-image-mapper-service";
+}

--- a/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
@@ -21,6 +21,7 @@ public class OsCapability extends Capability {
     public enum Architecture {
         x86_32,
         x86_64,
+        POWER_PC
         // might grow
     }
 
@@ -38,6 +39,10 @@ public class OsCapability extends Capability {
         FEDORA,
         RHEL,
         UBUNTU,
+        CENTOS,
+        ALPINE,
+        BUSYBOX,
+        OPEN_SUSE,
         // might grow
     }
 

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
@@ -1,0 +1,164 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
+import org.opentosca.toscana.core.Profiles;
+import org.opentosca.toscana.model.capability.OsCapability;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.DockerRegistry;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model.Image;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model.ImageTag;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model.ImageTags;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.model.DockerImage;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.model.DockerImageTag;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ This class allows the mapping of OsCapabilities (from a tosca model) to a docker base image.
+ When initialized with Spring this class will automatically download the latest tags from the base images
+ defined in the <code>DockerBaseImages</code> every 24 hours (by default).
+ To update this value please modify the <code>toscana.docker.base-image-mapper.update-interval</code> property (value in
+ hours)
+ */
+@Service
+@Profile("!" + Profiles.EXCLUDE_BASE_IMAGE_MAPPER)
+@SuppressWarnings("ConstantConditions")
+public class BaseImageMapper {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseImageMapper.class);
+
+    /**
+     Stores the update intervall for the base Image mappings (in hours)
+     Taken from the property value:
+     <code>toscana.docker.base-image-mapper.update-interval</code>
+     */
+    @Value("${toscana.docker.base-image-mapper.update-interval}")
+    private int updateInterval;
+
+    /**
+     This field is used to check the last update timestamp
+     */
+    private long lastUpdate;
+    /**
+     The map containing the "raw" tag data collected from dockerhub
+     */
+    private Map<String, DockerImage> imageMap = new HashMap<>();
+
+    /**
+     A array conatinig the base images that this Base Image Mapper tries to map to
+     this usually is <code>DockerBaseImages.values()</code>
+     */
+    private final DockerBaseImages[] baseImages;
+
+    private MapperEngine engine;
+
+    @Autowired
+    public BaseImageMapper(DockerBaseImages[] dockerBaseImages) {
+        this.baseImages = dockerBaseImages;
+        engine = new MapperEngine(imageMap);
+    }
+
+    /**
+     Toggles the first update of the mappings during initialisation in spring
+     */
+    @PostConstruct
+    private void postConstruct() {
+        updateBaseImageMap();
+    }
+
+    /**
+     Performs the Update of each image and sets the "last update" timestamp at the end
+     */
+    private void updateBaseImageMap() {
+        logger.info("Updating BaseImage Mappings");
+        for (DockerBaseImages baseImage : baseImages) {
+            logger.debug("Fetching tags for base image {}", baseImage.name());
+            List<ImageTags> tags = fetchImageTags(baseImage);
+            if (tags != null) {
+                addImagesForType(baseImage, tags);
+            }
+        }
+        lastUpdate = System.currentTimeMillis();
+        logger.info("Mappings have been updated. The next update will be executed in approx. {} hours", updateInterval);
+    }
+
+    /**
+     This is the spring scheduled job used to perform the updates after the frist one
+     <p>
+     This method gets called every 10 minutes and if the Current timestamp is larger than the old one plus the time
+     perion
+     it triggers a update of the mapping tables
+     */
+    @Scheduled(fixedRate = 600000)
+    private void updateCronjob() {
+        long time = System.currentTimeMillis();
+        if (time >= (lastUpdate + updateInterval * 3600 * 1000)) {
+            updateBaseImageMap();
+        }
+    }
+
+    /**
+     Internal method used for converting the Data received from docker to the data model described
+     in the <code>model</code> package
+     */
+    private void addImagesForType(DockerBaseImages baseImage, List<ImageTags> pages) {
+        logger.debug("Remapping Tags for Base image {}", baseImage.name());
+        List<DockerImageTag> tagList = new ArrayList<>();
+        for (ImageTags page : pages) {
+            for (ImageTag imageTag : page.getImageTags()) {
+                Set<String> architectures = new HashSet<>();
+                for (Image image : imageTag.getImages()) {
+                    //Because of older versions the architecture might be null, we assume the image
+                    //is amd64 in that case.
+                    if (image.getArchitecture() == null) {
+                        architectures.add("amd64");
+                    } else {
+                        architectures.add(image.getArchitecture());
+                    }
+                }
+                DockerImageTag tag = new DockerImageTag(imageTag.getName(), architectures);
+                tagList.add(tag);
+            }
+        }
+        imageMap.put(baseImage.name().toLowerCase(), new DockerImage(baseImage, tagList));
+    }
+
+    protected void setImageMap(Map<String, DockerImage> imageMap) {
+        this.imageMap = imageMap;
+        this.engine = new MapperEngine(imageMap);
+    }
+
+    protected Map<String, DockerImage> getImageMap() {
+        return imageMap;
+    }
+
+    /**
+     Downloads the tags for a given base image
+     */
+    private List<ImageTags> fetchImageTags(DockerBaseImages image) {
+        DockerRegistry registry = new DockerRegistry(image.getRegistry());
+        return registry.getTagsForRepository(image.getUsername(), image.getRepository());
+    }
+
+    /**
+     This method attempts to map a OsCapability to a docker base image.
+     If the mapping fails a UnsopportedOperationException is thrown. Reasons for failiure are: Invalid Architecture,
+     Unsupported type, Unknown version...
+     */
+    public String mapToBaseImage(OsCapability capability) {
+        return engine.mapToBaseImage(capability);
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapperConfiguration.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapperConfiguration.java
@@ -1,0 +1,19 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import org.opentosca.toscana.core.Profiles;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@Profile("!" + Profiles.EXCLUDE_BASE_IMAGE_MAPPER)
+public class BaseImageMapperConfiguration {
+
+    @Bean
+    public DockerBaseImages[] getDockerBaseImages() {
+        return DockerBaseImages.values();
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/DockerBaseImages.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/DockerBaseImages.java
@@ -1,0 +1,34 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperConstants.DOCKER_HUB_URL;
+
+public enum DockerBaseImages {
+    UBUNTU("library", "ubuntu", DOCKER_HUB_URL),
+    DEBIAN("library", "debian", DOCKER_HUB_URL),
+    CENTOS("library", "centos", DOCKER_HUB_URL),
+    ALPINE("library", "alpine", DOCKER_HUB_URL),
+    BUSYBOX("library", "busybox", DOCKER_HUB_URL),
+    OPEN_SUSE("library", "opensuse", DOCKER_HUB_URL);
+
+    private final String username;
+    private final String repository;
+    private final String registry;
+
+    DockerBaseImages(String username, String repository, String registry) {
+        this.username = username;
+        this.repository = repository;
+        this.registry = registry;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getRegistry() {
+        return registry;
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperConstants.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperConstants.java
@@ -1,0 +1,27 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opentosca.toscana.model.capability.OsCapability.Architecture;
+
+import static org.opentosca.toscana.model.capability.OsCapability.Architecture.x86_32;
+import static org.opentosca.toscana.model.capability.OsCapability.Architecture.x86_64;
+
+public class MapperConstants {
+    public static final String DEFAULT_IMAGE_PATH = "library/ubuntu:latest";
+    public static final String DEFAULT_IMAGE_DISTRO = "ubuntu";
+    public static final String DOCKER_HUB_URL = "https://registry.hub.docker.com";
+    public static final Map<Architecture, String> ARCHITECTURE_MAP;
+
+    static {
+        HashMap<Architecture, String> archMap = new HashMap<>();
+
+        //Map TOSCA Architecture strings to Docker architecture description strings
+        archMap.put(x86_32, "i386");
+        archMap.put(x86_64, "amd64");
+
+        ARCHITECTURE_MAP = Collections.unmodifiableMap(archMap);
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperEngine.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperEngine.java
@@ -1,0 +1,205 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.opentosca.toscana.model.capability.OsCapability;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.model.DockerImage;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.model.DockerImageTag;
+
+import com.vdurmont.semver4j.Semver;
+
+import static org.opentosca.toscana.model.capability.OsCapability.Architecture.x86_64;
+import static org.opentosca.toscana.model.capability.OsCapability.Type.LINUX;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperConstants.ARCHITECTURE_MAP;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperConstants.DEFAULT_IMAGE_DISTRO;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperConstants.DEFAULT_IMAGE_PATH;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperUtils.TAG_COMPARATOR_MINOR_VERSION;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperUtils.anythingSet;
+
+/**
+ This class wraps the mapping functionality of the Base image mapper
+ */
+class MapperEngine {
+
+    private final Map<String, DockerImage> imageMap;
+
+    public MapperEngine(Map<String, DockerImage> imageMap) {
+        this.imageMap = imageMap;
+    }
+
+    /**
+     This method attempts to map a OsCapability to a docker base image.
+     If the mapping fails a UnsopportedOperationException is thrown. Reasons for failiure are: Invalid Architecture,
+     Unsupported type, Unknown version...
+     */
+    public String mapToBaseImage(OsCapability capability) {
+        //Return default image if noting is present
+        if (!anythingSet(capability)) {
+            return DEFAULT_IMAGE_PATH;
+        }
+
+        String tag = null;
+        String distro = null;
+
+        //Check if the type (if set) is not linux. If so: the mapping fails
+        if (capability.getType().isPresent() && !capability.getType().get().equals(LINUX)) {
+            throw new UnsupportedOperationException("Could not map to base image. " +
+                "Only linux based images are supported");
+        }
+
+        //Check if the Distribution (if set) can be mapped to a docker image. If thats possible the mapping will continue
+        //otherwise it will fail
+        if (capability.getDistribution().isPresent() && !hasKnownDistributionName(capability)) {
+            throw new UnsupportedOperationException("Could not map to base image, " +
+                "because the distribution '" + capability.getDistribution().get() + "' is not supported.");
+        } else if (!capability.getDistribution().isPresent()) {
+            tag = "latest";
+            distro = DEFAULT_IMAGE_DISTRO;
+        } else {
+            distro = convertDistributionName(capability);
+            if (!capability.getVersion().isPresent()) {
+                tag = "latest";
+            } else {
+                String version = capability.getVersion().get();
+                DockerImage img = imageMap.get(distro);
+                Optional<DockerImageTag> imgTag = img.findTagByName(version);
+                if (imgTag.isPresent()) {
+                    tag = imgTag.get().getName();
+                } else {
+                    tag = lookForPossibleTag(version, img);
+                }
+            }
+        }
+        return performMapping(capability, tag, distro);
+    }
+
+    /**
+     This method looks for a possible tag for the given version and Docker Image, Throws a unsupported operation
+     exception if it fails
+     */
+    private String lookForPossibleTag(String version, DockerImage img) {
+        String tag;//Check if the Version definition is too specific e.g. ubuntu 16.04.3 that is non existant on dockerhub
+        Semver semVer = new Semver(version, Semver.SemverType.LOOSE);
+
+        List<DockerImageTag> eqMayorVersionTags = getTagsWithEqualMayorVersion(img, semVer.getMajor());
+
+        List<DockerImageTag> possibleMinorImageTags = getPossibleMinorImageTags(semVer, eqMayorVersionTags);
+
+        // If there is only one possibility return it.
+        if (possibleMinorImageTags.size() == 1) {
+            tag = possibleMinorImageTags.get(0).getName();
+        } else {
+            tag = determineTagFromMinorVersion(possibleMinorImageTags, semVer);
+        }
+        return tag;
+    }
+
+    /**
+     Searches for tags with a equal mayor version
+     */
+    private List<DockerImageTag> getTagsWithEqualMayorVersion(DockerImage img, int versionNumber) {
+        //Get all tags with the same mayor version (index 0) this one is required to be equal
+        List<DockerImageTag> eqMajorVersionTags = img.getVersionableTags().stream()
+            .filter(e -> e.toVersion().getMajor() == versionNumber).collect(Collectors.toList());
+
+        //Fail if there are no tags with the same major version
+        if (eqMajorVersionTags.size() == 0) {
+            throw new UnsupportedOperationException("Could not find base image. " +
+                "No tag with major version '" + versionNumber + "' found.");
+        }
+        return eqMajorVersionTags;
+    }
+
+    /**
+     Looks for tags that have none or a greater or equal minor version
+     */
+    private List<DockerImageTag> getPossibleMinorImageTags(Semver version, List<DockerImageTag> eqMayorVersionTags) {
+        // Look for minor version candidates (has to be be greater or equal to the version number given)
+        // A check if the value exists is not needed because the array length is at least 2
+        List<DockerImageTag> possibleMinorImageTags = eqMayorVersionTags.stream()
+            .filter(e -> e.toVersion().getMinor() >= version.getMinor()).collect(Collectors.toList());
+        possibleMinorImageTags.sort(TAG_COMPARATOR_MINOR_VERSION);
+
+        // If no image fulfilling the condition is found, the mapping fails
+        if (possibleMinorImageTags.size() == 0) {
+            throw new UnsupportedOperationException("Could not find base image. " +
+                "No tag with greater or equal minor version '" + version + "' found.");
+        }
+        return possibleMinorImageTags;
+    }
+
+    /**
+     Tries to determine the tag from the list of possible minor versions
+     */
+    private String determineTagFromMinorVersion(List<DockerImageTag> possibleTags, Semver version) {
+        DockerImageTag resultTag = null;
+        int i = 0;
+        DockerImageTag tag;
+        Semver tagVersion;
+        do {
+            tag = possibleTags.get(i);
+            tagVersion = tag.toVersion();
+            if (tagVersion.getMinor() == version.getMinor()) {
+                int j = i;
+                DockerImageTag prev = null;
+                DockerImageTag t = null;
+                Semver tv;
+                do {
+                    prev = t;
+                    t = possibleTags.get(j);
+                    tv = t.toVersion();
+                    j++;
+                } while (tv.getMinor().equals(version.getMinor()) && j < possibleTags.size());
+                resultTag = prev;
+            }
+            i++;
+        } while (i < possibleTags.size());
+        if (resultTag == null) {
+            throw new UnsupportedOperationException("Mapping failed");
+        }
+        return resultTag.getName();
+    }
+
+    /**
+     Perfoms the mapping to the base image
+     */
+    private String performMapping(OsCapability capability, String tag, String distro) {
+        DockerImage img = imageMap.get(distro);
+        String architecture = getCapabilityArchitecture(capability)
+            .orElseThrow(() -> new UnsupportedOperationException("Architecture not supported!"));
+
+        DockerImageTag imgTag = img.findTagByName(tag).get();
+        if (imgTag.isSupported(architecture)) {
+            return img.getUsername() + "/" + img.getRepository() + ":" + imgTag.getName();
+        } else {
+            throw new UnsupportedOperationException("Could not map to base image. " +
+                "The image '" + img.getUsername() + "/" + img.getRepository() + ":" + tag + "' " +
+                "does not support the architecture " + architecture);
+        }
+    }
+
+    /**
+     Converts the architecture of the capability to a architecture supported by docker
+     */
+    private Optional<String> getCapabilityArchitecture(OsCapability capability) {
+        return Optional.ofNullable(ARCHITECTURE_MAP.get(capability.getArchitecture().orElse(x86_64)));
+    }
+
+    private boolean hasKnownDistributionName(OsCapability capability) {
+        if (capability.getDistribution().isPresent()) {
+            String distroName = convertDistributionName(capability);
+            DockerImage image = imageMap.get(distroName);
+            return image != null;
+        }
+        return false;
+    }
+
+    private String convertDistributionName(OsCapability capability) {
+        return capability.getDistribution().get().name()         // Retrieve distro name
+            .toLowerCase()                                       // Convert to lower case
+            .replace(" ", "");                // Strip spaces from string
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperUtils.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperUtils.java
@@ -1,0 +1,24 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+
+import org.opentosca.toscana.model.capability.OsCapability;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.model.DockerImageTag;
+
+public class MapperUtils {
+
+    public static final Comparator<DockerImageTag> TAG_COMPARATOR_MINOR_VERSION =
+        Comparator.comparing(DockerImageTag::toVersion);
+
+    public static boolean anythingSet(OsCapability capability) {
+        Optional[] optionals = {
+            capability.getDistribution(),
+            capability.getArchitecture(),
+            capability.getType(),
+            capability.getVersion()
+        };
+        return Arrays.stream(optionals).anyMatch(Optional::isPresent);
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
@@ -1,0 +1,78 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model.ImageTags;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+/**
+ This class implements api access to a docker registry using the Registry version 2 API
+ <p>
+ To connect to the registry retrofit is used and wrapped in this class.
+ */
+public class DockerRegistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(DockerRegistry.class);
+
+    private RegistryService service;
+
+    private final String baseUrl;
+
+    public DockerRegistry(String baseURL) {
+        this.baseUrl = baseURL;
+        initRetrofit(baseURL);
+    }
+
+    /**
+     Helper method to initilialize retrofit
+     */
+    private void initRetrofit(String url) {
+        logger.debug("Initializing Retrofit for Registry {}", url);
+        Retrofit retrofit = new Retrofit.Builder()
+            .baseUrl(url)
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build();
+        service = retrofit.create(RegistryService.class);
+    }
+
+    /**
+     Returns all tags for a Repository on this registry.
+     <p>
+     This is a list, because the api splits this into pages
+     */
+    public List<ImageTags> getTagsForRepository(String user, String repository) {
+        Object next;
+        int page = 1;
+        List<ImageTags> imageTags = new ArrayList<>();
+        do {
+            Response<ImageTags> response = null;
+            try {
+                response = service.getTagsForRepository(user, repository, page).execute();
+                if (!response.isSuccessful()) {
+                    throw new IOException("Request failed, Invalid response code");
+                }
+                imageTags.add(response.body());
+                next = response.body().getNext();
+                page++;
+            } catch (Exception e) {
+                logger.error("Execution of the request failed", e);
+                logger.error("Processing failed: For {}/{} (Page {}) on '{}'", user, repository, page, baseUrl);
+                try {
+                    logger.error("The Server responded {}", (response.errorBody() != null) ? response.errorBody().string() : "");
+                } catch (Exception ex) {
+                    logger.error("Printing error response failed.", ex);
+                    ex.printStackTrace();
+                }
+                return null;
+            }
+        } while (next != null);
+        return imageTags;
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/RegistryService.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/RegistryService.java
@@ -1,0 +1,18 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api;
+
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model.ImageTags;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface RegistryService {
+
+    @GET("/v2/repositories/{username}/{repository}/tags")
+    Call<ImageTags> getTagsForRepository(
+        @Path("username") String username,
+        @Path("repository") String repository,
+        @Query("page") int page
+    );
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/Image.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/Image.java
@@ -1,0 +1,45 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ This class represtents one image (belonging to a tag) of a repository.
+ <p>
+ This class is only used to fetch the data from the registry.
+ <p>
+ Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Image {
+
+    @JsonProperty("architecture")
+    private String architecture;
+    /**
+     This field and its corresponding getter/setter is needed to parse the data, it contains all the fields that
+     have not been asigned to any field explicitly, because it is not needed.
+     */
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @JsonProperty("architecture")
+    public String getArchitecture() {
+        return architecture;
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTag.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTag.java
@@ -1,0 +1,59 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ This class represents one tag of a repository on a registry.
+ <p>
+ This class is only used to fetch the data from the registry.
+ <p>
+ Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ImageTag {
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("images")
+    private List<Image> images = null;
+
+    /**
+     This field and its corresponding getter/setter is needed to parse the data, it contains all the fields that 
+     have not been asigned to any field explicitly, because it is not needed.
+     */
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+    
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("images")
+    public List<Image> getImages() {
+        return images;
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTags.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTags.java
@@ -1,0 +1,54 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ This class represents a whole repository and its corresponding images (tags)
+ <p>
+ This class is only used to fetch the data from the registry.
+ <p>
+ Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ImageTags {
+
+    @JsonProperty("next")
+    private Object next;
+    @JsonProperty("results")
+    private List<ImageTag> imageTags = null;
+
+    /**
+     This field and its corresponding getter/setter is needed to parse the data, it contains all the fields that 
+     have not been asigned to any field explicitly, because it is not needed.
+     */
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @JsonProperty("next")
+    public Object getNext() {
+        return next;
+    }
+
+    @JsonProperty("results")
+    public List<ImageTag> getImageTags() {
+        return imageTags;
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/model/DockerImage.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/model/DockerImage.java
@@ -1,0 +1,64 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.model;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.DockerBaseImages;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ This class represents a repository on a Docker Registry with its corresponding tags (Docker Image Tags)
+ */
+public class DockerImage {
+    private String username;
+    private String repository;
+    private String registry;
+    private List<DockerImageTag> tags;
+
+    @JsonCreator
+    public DockerImage(
+        @JsonProperty("username") String username,
+        @JsonProperty("repository") String repository,
+        @JsonProperty("registry") String registry,
+        @JsonProperty("tags") List<DockerImageTag> tags
+    ) {
+        this.username = username;
+        this.repository = repository;
+        this.registry = registry;
+        this.tags = tags;
+    }
+
+    public DockerImage(DockerBaseImages image, List<DockerImageTag> tags) {
+        this(image.getUsername(), image.getRepository(), image.getRegistry(), tags);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public List<DockerImageTag> getTags() {
+        return tags;
+    }
+
+    @JsonIgnore
+    public Optional<DockerImageTag> findTagByName(String name) {
+        return tags.stream().filter(e -> e.getName().equalsIgnoreCase(name)).findFirst();
+    }
+
+    @JsonIgnore
+    public List<DockerImageTag> getVersionableTags() {
+        return tags.stream().filter(DockerImageTag::isVersionable).collect(Collectors.toList());
+    }
+
+    public String getRegistry() {
+        return registry;
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/model/DockerImageTag.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/model/DockerImageTag.java
@@ -1,0 +1,59 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.model;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vdurmont.semver4j.Semver;
+
+/**
+ This class represents a Tag for a Repository (image) on a docker registry.
+ */
+public class DockerImageTag {
+    private String name;
+    private Set<String> supportedArchitectures;
+
+    public DockerImageTag(
+        @JsonProperty("name") String name,
+        @JsonProperty("supportedArchitectures") Set<String> supportedImageTags
+    ) {
+        this.name = name;
+        this.supportedArchitectures = supportedImageTags;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Set<String> getSupportedArchitectures() {
+        return supportedArchitectures;
+    }
+
+    @JsonIgnore
+    public boolean isVersionable() {
+        try {
+            new Semver(name, Semver.SemverType.LOOSE);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @JsonIgnore
+    public Semver toVersion() {
+        if (!isVersionable()) {
+            throw new UnsupportedOperationException("The tag '" + name + "' is not versionable.");
+        }
+        return new Semver(name, Semver.SemverType.LOOSE);
+    }
+
+    public boolean isSupported(String architecture) {
+        return supportedArchitectures.contains(architecture.toLowerCase());
+    }
+
+    @Override
+    public String toString() {
+        return "DockerImageTag(name='" + name + "', supportedArchitectures=" + Arrays.toString(supportedArchitectures.toArray()) + ")";
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -3,6 +3,13 @@
 ###############################
 server:
     port: 8084
+toscana:
+    docker:
+        base-image-mapper:
+            # This defines the Update interval of the Base Image Mapper.
+            # it will update the Base images every x Hours
+            update-interval: 24
+
 
 ################################
 ##### Spring HTTP Settings #####

--- a/server/src/test/java/org/opentosca/toscana/core/BaseTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/BaseTest.java
@@ -6,7 +6,9 @@ import org.opentosca.toscana.core.testutils.TestCategory;
 import org.junit.Rule;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles( {Profiles.EXCLUDE_BASE_IMAGE_MAPPER})
 @TestCategory(value = TestCategories.FAST)
 public abstract class BaseTest {
 

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperErrorTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperErrorTest.java
@@ -1,0 +1,111 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.opentosca.toscana.core.BaseJUnitTest;
+import org.opentosca.toscana.model.capability.OsCapability;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.opentosca.toscana.model.capability.OsCapability.Architecture.POWER_PC;
+import static org.opentosca.toscana.model.capability.OsCapability.Distribution.DEBIAN;
+import static org.opentosca.toscana.model.capability.OsCapability.Distribution.RHEL;
+import static org.opentosca.toscana.model.capability.OsCapability.Distribution.UBUNTU;
+import static org.opentosca.toscana.model.capability.OsCapability.Type.LINUX;
+import static org.opentosca.toscana.model.capability.OsCapability.Type.WINDOWS;
+import static org.opentosca.toscana.model.capability.OsCapability.builder;
+
+@RunWith(Parameterized.class)
+public class MapperErrorTest extends BaseJUnitTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(MapperErrorTest.class);
+    private static BaseImageMapper baseImageMapper;
+
+    private String name;
+    private OsCapability capability;
+    private Class<? extends Exception> expectedException;
+
+    public MapperErrorTest(
+        String name,
+        OsCapability capability,
+        Class<? extends Exception> expectedException
+    ) {
+        this.name = name;
+        this.capability = capability;
+        this.expectedException = expectedException;
+    }
+
+    @Test
+    public void execute() throws Exception {
+        try {
+            logger.info("Executing test {}", name);
+            logger.info("Trying to map {}", capability.toString());
+            baseImageMapper.mapToBaseImage(capability);
+        } catch (Throwable e) {
+            logger.info("Thrown exception (was expected)", e);
+            assertTrue(
+                "Thrown exception is not of type: " + expectedException.getName(),
+                expectedException.isInstance(e)
+            );
+            return;
+        }
+        fail();
+    }
+
+    @BeforeClass
+    public static void initBaseImageMapper() throws Exception {
+        logger.info("Initializing Base image Mapper");
+        baseImageMapper = MapperTest.init();
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]
+                {
+                    {
+                        "Invalid Type",
+                        builder().type(WINDOWS).build(),
+                        UnsupportedOperationException.class
+                    },
+                    {
+                        "Missing Type, Invalid Distribution",
+                        builder().distribution(RHEL).build(),
+                        UnsupportedOperationException.class
+                    },
+                    {
+                        "Vaild Type, Invalid Distribution",
+                        builder().type(LINUX).distribution(RHEL).build(),
+                        UnsupportedOperationException.class
+                    },
+                    {
+                        "Vaild Type, Valid Distribution, Unknown Version",
+                        builder().distribution(DEBIAN).type(LINUX).version("123456").build(),
+                        UnsupportedOperationException.class
+                    },
+                    {
+                        "Vaild Type, Valid Distribution, Unknown Version(With dots)",
+                        builder().distribution(DEBIAN).type(LINUX).version("12345.6").build(),
+                        UnsupportedOperationException.class
+                    },
+                    {
+                        "Vaild Type, Valid Distribution, No Applicable minor version",
+                        builder().type(LINUX).distribution(UBUNTU).version("17.11").build(),
+                        UnsupportedOperationException.class
+                    },
+                    {
+                        "Vaild Type, Valid Distribution, Invalid Architecture",
+                        builder().architecture(POWER_PC).type(LINUX).distribution(UBUNTU).build(),
+                        UnsupportedOperationException.class
+                    }
+                }
+        );
+    }
+}

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
@@ -1,0 +1,56 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.util.Map;
+
+import org.opentosca.toscana.core.integration.BaseIntegrationTest;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.opentosca.toscana.model.capability.OsCapability.Distribution.DEBIAN;
+import static org.opentosca.toscana.model.capability.OsCapability.builder;
+
+@ActiveProfiles( {"bimloader"})
+@ContextConfiguration(classes = {MapperLoaderTest.BIMTestConfiguration.class})
+public class MapperLoaderTest extends BaseIntegrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(MapperLoaderTest.class);
+
+    @Autowired
+    private BaseImageMapper mapper;
+
+    @Test
+    public void testLoader() throws Exception {
+        String image = mapper.mapToBaseImage(
+            builder().distribution(DEBIAN).build()
+        );
+        logger.info("Performed a mapping to {}", image);
+        Map data = mapper.getImageMap();
+        assertEquals(DockerBaseImages.values().length, data.size());
+    }
+
+    @Profile("bimloader")
+    @Configuration
+    @EnableScheduling
+    public static class BIMTestConfiguration {
+
+        @Bean
+        public DockerBaseImages[] getDockerBaseImages() {
+            return DockerBaseImages.values();
+        }
+
+        @Bean
+        public BaseImageMapper getBaseImageMapper(@Autowired DockerBaseImages[] img) {
+            return new BaseImageMapper(img);
+        }
+    }
+}

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
@@ -1,0 +1,122 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.opentosca.toscana.core.BaseJUnitTest;
+import org.opentosca.toscana.model.capability.OsCapability;
+import org.opentosca.toscana.model.capability.OsCapability.Distribution;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.util.DataContainer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.opentosca.toscana.model.capability.OsCapability.Architecture.x86_64;
+import static org.opentosca.toscana.model.capability.OsCapability.Type.LINUX;
+import static org.opentosca.toscana.model.capability.OsCapability.builder;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.DockerBaseImages.ALPINE;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.DockerBaseImages.DEBIAN;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.DockerBaseImages.UBUNTU;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperConstants.DEFAULT_IMAGE_PATH;
+
+@RunWith(Parameterized.class)
+public class MapperTest extends BaseJUnitTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(MapperTest.class);
+    private static BaseImageMapper baseImageMapper;
+
+    private String name;
+    private OsCapability capability;
+    private String expectedImage;
+
+    public MapperTest(String name, OsCapability capability, String expectedImage) {
+        this.name = name;
+        this.capability = capability;
+        this.expectedImage = expectedImage;
+    }
+
+    @Test
+    public void test() throws Exception {
+        logger.info("Executing test {}", name);
+        String image = baseImageMapper.mapToBaseImage(capability);
+        logger.info("Mapped capability {} to {}. Expected is {}", capability.toString(), image, expectedImage);
+        assertEquals(expectedImage, image);
+    }
+
+    @BeforeClass
+    public static void initBaseImageMapper() throws Exception {
+        logger.info("Initializing Base image Mapper");
+
+        baseImageMapper = init();
+    }
+
+    public static BaseImageMapper init() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        InputStream in = BaseImageMapper.class.getClassLoader()
+            .getResourceAsStream("kubernetes/base-image-mapper/image-map.json");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IOUtils.copy(in, out);
+        BaseImageMapper baseImageMapper = new BaseImageMapper(new DockerBaseImages[] {
+            ALPINE,
+            DEBIAN,
+            UBUNTU
+        });
+        DataContainer data = mapper.readValue(new String(out.toByteArray()), DataContainer.class);
+
+        baseImageMapper.setImageMap(data.data);
+
+        return baseImageMapper;
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]
+            {
+                {
+                    "Empty Capability",
+                    builder().build(),
+                    DEFAULT_IMAGE_PATH
+                },
+                {
+                    "Specific Version",
+                    builder().type(LINUX).distribution(Distribution.DEBIAN).version("9.2").build(),
+                    "library/debian:9.2"
+                },
+                {
+                    "Version too specific",
+                    builder().type(LINUX).distribution(Distribution.UBUNTU).version("16.04.3").build(),
+                    "library/ubuntu:16.04"
+                },
+                {
+                    "Version not found but newer fix version available",
+                    builder().type(LINUX).distribution(Distribution.UBUNTU).version("12.04.3").build(),
+                    "library/ubuntu:12.04.5"
+                },
+                {
+                    "Specific Version not found (Expect later version)",
+                    builder().type(LINUX).distribution(Distribution.UBUNTU).version("17.09").build(),
+                    "library/ubuntu:17.10"
+                },
+                {
+                    "Architecture Only",
+                    builder().architecture(x86_64).build(),
+                    DEFAULT_IMAGE_PATH
+                },
+                {
+                    "Missing Distribution",
+                    builder().type(LINUX).version("17.09").build(),
+                    DEFAULT_IMAGE_PATH
+                },
+            }
+        );
+    }
+}

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperUtilsTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperUtilsTest.java
@@ -1,0 +1,24 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import org.opentosca.toscana.core.BaseJUnitTest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.opentosca.toscana.model.capability.OsCapability.Type;
+import static org.opentosca.toscana.model.capability.OsCapability.builder;
+import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperUtils.anythingSet;
+
+public class MapperUtilsTest extends BaseJUnitTest {
+
+    @Test
+    public void testNoneSet() throws Exception {
+        assertFalse(anythingSet(builder().build()));
+    }
+
+    @Test
+    public void testOneSet() throws Exception {
+        assertTrue(anythingSet(builder().type(Type.LINUX).build()));
+    }
+}

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/util/DataContainer.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/util/DataContainer.java
@@ -1,0 +1,9 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.util;
+
+import java.util.Map;
+
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.model.DockerImage;
+
+public class DataContainer {
+    public Map<String, DockerImage> data;
+}

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/util/MapperTestConfiguration.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/util/MapperTestConfiguration.java
@@ -1,0 +1,26 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper.util;
+
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.BaseImageMapper;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperTest;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ Import this annotation if you need the base image mapper in your integration tests
+ it will load a file from the test resources in order to perform the mappings.
+ To keep loading times at a minimum
+ add it using the following annotation on the class
+ <code>@ContextConfiguration(classes = {MapperTestConfiguration.class})</code>
+ and
+ <code>@ActiveProfiles({"base-image-mapper"})</code>
+ */
+@Profile("base-image-mapper")
+@Configuration
+public class MapperTestConfiguration {
+    @Bean
+    public BaseImageMapper mapper() throws Exception {
+        return MapperTest.init();
+    }
+}

--- a/server/src/test/resources/kubernetes/base-image-mapper/image-map.json
+++ b/server/src/test/resources/kubernetes/base-image-mapper/image-map.json
@@ -1,0 +1,3302 @@
+{
+    "data": {
+        "open_suse": {
+            "username": "library",
+            "repository": "opensuse",
+            "registry": "https://registry.hub.docker.com",
+            "tags": [
+                {
+                    "name": "tumbleweed",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "harlequin",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "13.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "42.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "42.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "latest",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "leap",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "42.3",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "13.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "bottle",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                }
+            ]
+        },
+        "busybox": {
+            "username": "library",
+            "repository": "busybox",
+            "registry": "https://registry.hub.docker.com",
+            "tags": [
+                {
+                    "name": "1.27.2",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "latest",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "musl",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1-musl",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27-musl",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.2-musl",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "glibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1-glibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27-glibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.2-glibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "uclibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1-uclibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27-uclibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.2-uclibc",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.1-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.1-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.1-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.0",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.0-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.0-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.27.0-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.2-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.2-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.2-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.1-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.1-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.1-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.0",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.0-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.0-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.26.0-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.1-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.1-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.1-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.0",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.0-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.0-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.25.0-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.2-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.2-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.2-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.1-uclibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.1-musl",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.1-glibc",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "ubuntu",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1-ubuntu",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.21-ubuntu",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.21.0-ubuntu",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.24.0",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.23",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "1.23.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buildroot-2013.08.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buildroot-2014.02",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "ubuntu-12.04",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "ubuntu-14.04",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                }
+            ]
+        },
+        "ubuntu": {
+            "username": "library",
+            "repository": "ubuntu",
+            "registry": "https://registry.hub.docker.com",
+            "tags": [
+                {
+                    "name": "zesty",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20171114",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "17.04",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "latest",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20171114",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "16.04",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20171117",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "14.04",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "devel",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "bionic",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "bionic-20171114",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "18.04",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "rolling",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20171116",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "17.10",
+                    "supportedArchitectures": [
+                        "386",
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170915",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20171006",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170817",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20171019",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20171006",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170915",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20170916",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170913",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20170826",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170703",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170802",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170728",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20170728",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20170704",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "16.10",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170710",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170719",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20170716",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170619",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20170619",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170619",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20170619",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170517.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20170517.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170517.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170602",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20170601",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "14.04.5",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170411",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20170327",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170510",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170330",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "artful-20170511.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170417.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20170331",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "12.04",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "12.04.5",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170410",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20170224",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170224",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170214",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170214",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20170214",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20170118",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20170104",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20170119",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20170119",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20161209",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20161213",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20161213",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20161212",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20161214",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "zesty-20161129.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20161121",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20161123",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20161121",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20161123",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20161104",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20161114",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20161101",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20161102",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20161013",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20161010",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20161006",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160923.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20160923.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160923.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160923.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20160919",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160914",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160914",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160819",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20160826",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160818",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160819",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160809",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160802",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20160806.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160707",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20160717",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160713",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160706",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "15.10",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160711",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "14.04.4",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "yakkety-20160708",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160706",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160624",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160629",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160602",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160624",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160525",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160526",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160526",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160526",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160503",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160503",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160503.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160503",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160422",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160424",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160424",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160425",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160412",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160331.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160329",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160405",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160330",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160323",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160317",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160316",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160317",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160318",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160314.4",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160302",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160315",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160311",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160303.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160302",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160303",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160226",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160217",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160226",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160225",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160217.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160217",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160217",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160125",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20160121",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20160122",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20160119",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20160108",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "15.04",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "14.04.3",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20160119.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20151208",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20151208",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "xenial-20151218.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20151218",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20151208",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20151208",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20151019",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20151111",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20151028",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20151028",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20151106",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "12.10",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150218.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150211",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "quantal",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "14.04.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "raring",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150218",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150309",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "10.04",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "saucy",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150228.11",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150228.11",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "13.10",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "13.04",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150212",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150228.11",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "lucid",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20151021",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20151021",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20151020",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20151009",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20151009",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20151006",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150930",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20151001",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150924",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20150829",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20150818",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150813",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150813",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150814",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20150807",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150806",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20150731",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150802",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150730",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150729",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20150708",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150625",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150630",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150626",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150528",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150528",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150528",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150319",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150418",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150427",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150612",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20150528.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150319.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "14.04.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150528",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150612",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150320",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150611",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "trusty-20150427",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wily-20150611",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150612",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "utopic-20150427",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "precise-20150320",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "14.10",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150427",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "vivid-20150421",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                }
+            ]
+        },
+        "debian": {
+            "username": "library",
+            "repository": "debian",
+            "registry": "https://registry.hub.docker.com",
+            "tags": [
+                {
+                    "name": "wheezy-slim",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wheezy-backports",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.11",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wheezy-20171009",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wheezy",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "unstable-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "unstable-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "unstable",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch-backports",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "latest",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "9",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "9.2",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable-backports",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "sid-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "sid-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "sid",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "rc-buggy-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "rc-buggy",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable-backports",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldoldstable-slim",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldoldstable-backports",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldoldstable-20171009",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldoldstable",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie-backports",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.9",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "experimental-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "experimental",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buster-slim",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buster-20171009",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buster",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wheezy-20170907",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "unstable-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "9.1",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "sid-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "rc-buggy-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldoldstable-20170907",
+                    "supportedArchitectures": [
+                        "arm",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "experimental-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buster-20170907",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wheezy-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "unstable-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "sid-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "rc-buggy-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldoldstable-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "experimental-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buster-20170723",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wheezy-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "unstable-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "9.0",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "sid-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "rc-buggy-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldoldstable-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.8",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "experimental-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "buster-20170620",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "wheezy-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "unstable-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing-backports",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "testing-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stretch-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "stable-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "sid-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "rc-buggy-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "oldstable-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "jessie-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "experimental-20170606",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.7",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.5",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.10",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.4",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.9",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.3",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "squeeze",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6.0",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6.0.10",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.5",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6.0.8",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6.0.9",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.7",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.4",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.3",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.0",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "8.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.8",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                }
+            ]
+        },
+        "alpine": {
+            "username": "library",
+            "repository": "alpine",
+            "registry": "https://registry.hub.docker.com",
+            "tags": [
+                {
+                    "name": "3.5",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "3.4",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "3.3",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "3.2",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "3.1",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "edge",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "latest",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "3.6",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "s390x",
+                        "arm",
+                        "ppc64le",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "2.7",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "2.6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                }
+            ]
+        },
+        "centos": {
+            "username": "library",
+            "repository": "centos",
+            "registry": "https://registry.hub.docker.com",
+            "tags": [
+                {
+                    "name": "6.6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos6.6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6.7",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos6.7",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6.8",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos6.8",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6.9",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos6.9",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.0.1406",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos7.0.1406",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.1.1503",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos7.1.1503",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.2.1511",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos7.2.1511",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.3.1611",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos7.3.1611",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7.4.1708",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos7.4.1708",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos6",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "7",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos7",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "latest",
+                    "supportedArchitectures": [
+                        "arm64",
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "5.11",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos5.11",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "5",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                },
+                {
+                    "name": "centos5",
+                    "supportedArchitectures": [
+                        "amd64"
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
For some information about what the mapper does please consult #218 and [BaseImageMapper Spec](https://github.com/StuPro-TOSCAna/TOSCAna/blob/2d72d374fff07c6ff694930e828df4f534f47b5d/docs/dev/plugins/kubernetes/dockerfile-mapping/base-image-mapper.md)

The following tasks will have to be done to complete this PR:
- [x] Create Special configuration to allow fast loading in tests. (Probably by injecting a map of data before the context gets created)
- [x] Replace `OSCapability` with the one from the model, or at least convert the one from the model to `OSCapability`
- [x] Document the Code
- [x] Update Specification document