### PR TITLE
Rework PluginFileAccess

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
+++ b/server/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
@@ -24,16 +24,30 @@ public class PluginFileAccess {
     }
 
     /**
-     Copies given file or directory from the csar content directory to the transformation directory.
-     If given path specifies a directory, this directory's content gets copied as well.
+     Copies given file or directory (recursively) from the csar content directory to the transformation directory.
+     After the successful call the copied files will reside in given path (relative to the transformation content dir)
 
-     @param relativePath the path to the source file relative to the csar's content directory
-     @throws FileNotFoundException if no file or directory was found for given path
+     @param relativePath path to the source file relative to the csar content directory
+     @throws FileNotFoundException if no file or directory was found for given relativePath
      @throws IOException           if an error occurred while copying
      */
     public void copy(String relativePath) throws FileNotFoundException, IOException {
-        File source = new File(sourceDir, relativePath);
-        File target = new File(targetDir, relativePath);
+        copy(relativePath, relativePath);
+    }
+
+    /**
+     Copies given file or directory (recursively) located at given relativeSourcePath to the given relativeTargetPath.
+     <p>
+     Note: Will create new directories if necessary.
+
+     @param relativeSourcePath path to the source file relative to the csar content directory
+     @param relativeTargetPath target location for the copy operation, relative to the transformation content dir
+     @throws FileNotFoundException if no file or directory was found for given relativeSourcePath
+     @throws IOException           if an error occured while copying
+     */
+    public void copy(String relativeSourcePath, String relativeTargetPath) throws FileNotFoundException, IOException {
+        File source = new File(sourceDir, relativeSourcePath);
+        File target = new File(targetDir, relativeTargetPath);
         if (!source.exists()) {
             logger.error("Failed to copy '{}': file not found", sourceDir);
             throw new FileNotFoundException();
@@ -90,6 +104,20 @@ public class PluginFileAccess {
         } catch (IOException e) {
             logger.error("Failed to read content from file '{}'", source);
             throw e;
+        }
+    }
+
+    /**
+     @param relativePath a path (relative to the transformation content directory) to a file or directory.
+     @return the absolute path for given relativePath.
+     @throws FileNotFoundException if no file is found for given relativePath
+     */
+    public String getAbsolutePath(String relativePath) throws FileNotFoundException {
+        File targetFile = new File(targetDir, relativePath);
+        if (targetFile.exists()) {
+            return targetFile.getAbsolutePath();
+        } else {
+            throw new FileNotFoundException(String.format("File '%s' not found", targetFile));
         }
     }
 }

--- a/server/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -80,6 +81,21 @@ public class PluginFileAccessTest extends BaseJUnitTest {
         String file = "nonexistent_file";
         access.copy(file);
     }
+    
+    @Test
+    public void copySourceToGivenTargetSuccessful() throws IOException {
+        String filename = "some-file";
+        File file = new File(sourceDir, filename);
+        file.createNewFile();
+        String alternativeDirName = "some-dir/nested/even-deeper";
+        File alternateDirectory = new File(targetDir, alternativeDirName);
+        File targetFile = new File(alternateDirectory, filename);
+        
+        String relativeTargetPath = String.format("%s/%s", alternativeDirName, filename);
+        access.copy(filename, relativeTargetPath);
+        
+        assertTrue(targetFile.exists());
+    }
 
     @Test
     public void write() throws Exception {
@@ -120,5 +136,22 @@ public class PluginFileAccessTest extends BaseJUnitTest {
     public void readFileNotExists() throws IOException {
         String path = "nonexistent-file";
         access.read(path);
+    }
+    
+    @Test
+    public void getAbsolutePathSuccess() throws IOException {
+        String filename = "some-source-file";
+        File sourceFile = new File(targetDir, filename);
+        sourceFile.createNewFile();
+        
+        String result = access.getAbsolutePath(filename);
+        assertEquals(sourceFile.getAbsolutePath(), result);
+    }
+    
+    @Test(expected = FileNotFoundException.class)
+    public void getAbsolutePathNoSuchFile() throws FileNotFoundException {
+        String filename = "nonexistent-file";
+        access.getAbsolutePath(filename);
+        fail("getAbsoultePath() should have raised FileNotFoundException.");
     }
 }


### PR DESCRIPTION
Resolves #191.
The PluginFileAccess did not meet the requirements of the plugins.
Added features:
- means to retrieve absolute paths of files contained in the
transformation content directory. E.g. this is neccessary when plugins
need to call external programs that need reference to files.
However, plugins will still not have any knownledge about the absolute
path of the source csar files. This will prevent ugly sideeffects (like
one plugin accidently modifies the source csar files, and another plugin
therefore fails)
- means to copy source files to different target location