### PR TITLE
Add delete method to PluginFileAccess

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
+++ b/server/src/main/java/org/opentosca/toscana/core/plugin/PluginFileAccess.java
@@ -120,4 +120,13 @@ public class PluginFileAccess {
             throw new FileNotFoundException(String.format("File '%s' not found", targetFile));
         }
     }
+
+    /**
+     Deletes file or directory (recusively) denoted by given path. If target does not exists, does nothing.
+     @param relativePath relative (to the transformation content directory) path to a file or directory.
+     */
+    public void delete(String relativePath) {
+        File file = new File(targetDir, relativePath);
+        FileUtils.deleteQuietly(file);
+    }
 }

--- a/server/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/plugin/PluginFileAccessTest.java
@@ -154,4 +154,15 @@ public class PluginFileAccessTest extends BaseJUnitTest {
         access.getAbsolutePath(filename);
         fail("getAbsoultePath() should have raised FileNotFoundException.");
     }
+    
+    @Test
+    public void delete() throws IOException {
+        String filename = "some-file";
+        File file = new File(targetDir, filename);
+        file.createNewFile();
+        assertTrue(file.exists());
+        
+        access.delete(filename);
+        assertFalse(file.exists());
+    }
 }


### PR DESCRIPTION
PluginFileAccess was lacking a delete method (e.g. for the plugin lifecycle phase 'cleanup').

Resolves #233.