### PR TITLE
Fix Lifecycle Transformations failing when run from a JAR

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/plugins/lifecycle/AbstractLifecycle.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/lifecycle/AbstractLifecycle.java
@@ -1,14 +1,17 @@
 package org.opentosca.toscana.plugins.lifecycle;
 
-import java.io.File;
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
 import org.opentosca.toscana.core.plugin.PluginFileAccess;
 import org.opentosca.toscana.core.transformation.TransformationContext;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 
 /**
@@ -26,6 +29,7 @@ public abstract class AbstractLifecycle implements TransformationLifecycle {
     public static final String SCRIPTS_DIR_PATH = OUTPUT_DIR_PATH + SCRIPTS_DIR_NAME;
     public static final String UTIL_DIR_NAME = "util/";
     public static final String UTIL_DIR_PATH = SCRIPTS_DIR_PATH + UTIL_DIR_NAME;
+    public static final String RESOURCE_PATH_BASE = "/plugins/scripts/util/";
 
     /**
      The transformation specific logger that can be used to log to the transformations Log Object
@@ -51,7 +55,22 @@ public abstract class AbstractLifecycle implements TransformationLifecycle {
     private void setUpDirectories(PluginFileAccess access) throws IOException {
         access.createDirectories(UTIL_DIR_PATH);
 
-        File sourceScriptUtils = new File(getClass().getResource("/plugins/scripts/util/").getFile());
-        FileUtils.copyDirectory(sourceScriptUtils, new File(access.getAbsolutePath(UTIL_DIR_PATH)));
+        //Iterate over all files in the script list
+        List<String> files = IOUtils.readLines(
+            getClass().getResourceAsStream(RESOURCE_PATH_BASE + "scripts-list"),
+            Charsets.UTF_8
+        );
+        for (String line : files) {
+            if (!line.isEmpty()) {
+                //Copy the file into the desired directory
+                InputStreamReader input = new InputStreamReader(
+                    getClass().getResourceAsStream(RESOURCE_PATH_BASE + line)
+                );
+                BufferedWriter output = access.access(UTIL_DIR_PATH + line);
+                IOUtils.copy(input, output);
+                input.close();
+                output.close();
+            }
+        }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/plugins/lifecycle/LifecycleAwarePlugin.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/lifecycle/LifecycleAwarePlugin.java
@@ -116,5 +116,5 @@ public abstract class LifecycleAwarePlugin<LifecycleT extends TransformationLife
      @param context The transformation context for which the Lifecycle interface should be built
      @return a newly constructed instance of the LifecycleInterface implemented by this plugin.
      */
-    protected abstract LifecycleT getInstance(TransformationContext context);
+    protected abstract LifecycleT getInstance(TransformationContext context) throws Exception;
 }

--- a/server/src/main/resources/plugins/scripts/util/scripts-list
+++ b/server/src/main/resources/plugins/scripts/util/scripts-list
@@ -1,0 +1,1 @@
+environment-check.sh


### PR DESCRIPTION
This PR Fixes #250.

It results in one consequence:
Every `util` script thats is added also has to be added to the `scripts-list` file. As far as i know, this is the easiest way to fix this issue. 
Instead of trying to copy a directory `getResourceAsStream()` is used to access the list file first. The other files get loaded using the names in the list File.