### PR TITLE
Remove NodeType check lifecycle phase

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/plugins/lifecycle/LifecycleAwarePlugin.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/lifecycle/LifecycleAwarePlugin.java
@@ -3,7 +3,6 @@ package org.opentosca.toscana.plugins.lifecycle;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import org.opentosca.toscana.core.plugin.AbstractPlugin;
 import org.opentosca.toscana.core.transformation.TransformationContext;
@@ -42,8 +41,6 @@ public abstract class LifecycleAwarePlugin<LifecycleT extends TransformationLife
                     " because the Environment check has failed!");
             }
         }));
-        //Node type Validation
-        executionTasks.add(new ExecutionPhase<>("check node types", this::checkNodeTypes));
         //Model validation
         executionTasks.add(new ExecutionPhase<>("check model", (e) -> {
             if (!e.checkModel()) {
@@ -60,9 +57,9 @@ public abstract class LifecycleAwarePlugin<LifecycleT extends TransformationLife
         //Make list immutable
         this.executionTasks = Collections.unmodifiableList(executionTasks);
     }
-    
+
     /**
-     Performs the executon of the phases in the order that has been defined during the construction of the object
+     Performs the execution of the phases in the order that has been defined during the construction of the object
 
      @param context context for the transformation
      */
@@ -87,16 +84,6 @@ public abstract class LifecycleAwarePlugin<LifecycleT extends TransformationLife
     }
 
     /**
-     Checks if all node types of the model are on the suppored list (returned by getSupportedNodeTypes()
-
-     @param lifecycle Probably never used, exists to use this::checkNodeTypes in a lambda expression
-     */
-    private void checkNodeTypes(LifecycleT lifecycle) {
-        Set<Class<?>> supported = getSupportedNodeTypes();
-        //TODO implement once model is done!
-    }
-
-    /**
      Checks if all required environment parameters like installed CLIs, running services (such as docker) are availiable
      if so the method will return true, false otherwise (results in failure of the transformation)
 
@@ -105,12 +92,6 @@ public abstract class LifecycleAwarePlugin<LifecycleT extends TransformationLife
     protected boolean checkEnvironment() {
         return true;
     }
-
-    /**
-     @return Returns a set of Classes of node types supported by this plugin. if the model contains classes that are not in
-     this set, the transformation will fail in the Node Type Validation phase
-     */
-    protected abstract Set<Class<? /* extends RootNode */>> getSupportedNodeTypes();
 
     /**
      @param context The transformation context for which the Lifecycle interface should be built

--- a/server/src/test/java/org/opentosca/toscana/plugins/lifecycle/LifecycleAwarePluginTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/lifecycle/LifecycleAwarePluginTest.java
@@ -1,8 +1,5 @@
 package org.opentosca.toscana.plugins.lifecycle;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.opentosca.toscana.core.BaseJUnitTest;
 import org.opentosca.toscana.core.testdata.TestPlugins;
 import org.opentosca.toscana.core.transformation.TransformationContext;
@@ -82,11 +79,6 @@ public class LifecycleAwarePluginTest extends BaseJUnitTest {
         @Override
         protected boolean checkEnvironment() {
             return envCheckReturnValue;
-        }
-
-        @Override
-        protected Set<Class<?>> getSupportedNodeTypes() {
-            return new HashSet<>();
         }
 
         @Override


### PR DESCRIPTION
As mentioned by @hnicke the default visitor methods throw an exception if there is an unimplemented node visitor. Therefore, the NodeType check life cycle phase is obsolete and can be removed.