### PR TITLE
Fix upload of invalid csar

### DIFF
--- a/cli/src/main/java/org/opentosca/toscana/cli/ApiController.java
+++ b/cli/src/main/java/org/opentosca/toscana/cli/ApiController.java
@@ -105,11 +105,7 @@ public class ApiController {
         if (response.code() == 201) {
             return con.CSAR_UPLOAD_SUCCESS;
         } else if (response.code() == 400) {
-            if (response.errorBody().string() != null) {
-                return con.CSAR_UPLOAD_ERROR400M + response.errorBody().string();
-            } else {
-                return con.CSAR_UPLOAD_ERROR400;
-            }
+            return con.CSAR_UPLOAD_ERROR400;
         } else if (response.code() == 500) {
             return con.CSAR_UPLOAD_ERROR500;
         } else {

--- a/cli/src/main/java/org/opentosca/toscana/cli/commands/Constants.java
+++ b/cli/src/main/java/org/opentosca/toscana/cli/commands/Constants.java
@@ -11,7 +11,6 @@ public final class Constants {
     public final String CSAR_UPLOAD_SUCCESS = "Upload of CSAR Archive was successful!";
     public final String CSAR_UPLOAD_ERROR = "Something went wrong while uploading the CSAR.";
     public final String CSAR_UPLOAD_ERROR400 = "Parsing of the CSAR failed.";
-    public final String CSAR_UPLOAD_ERROR400M = "A CSAR with given name already exists.\n";
     public final String CSAR_UPLOAD_ERROR500 = "Processing failed.\n";
     public final String CSAR_DELETE_SUCCESS = "Deletion of CSAR was successfull!";
     public final String CSAR_DELETE_ERROR = "Something went wrong while deleting the CSAR.";

--- a/cli/src/test/java/org/opentosca/toscana/cli/CsarTest.java
+++ b/cli/src/test/java/org/opentosca/toscana/cli/CsarTest.java
@@ -119,7 +119,7 @@ public class CsarTest {
         helper.server400Response();
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("csar/simple-task.csar").getFile());
-        assertEquals(con.CSAR_UPLOAD_ERROR400M, api.uploadCsar(file));
+        assertEquals(con.CSAR_UPLOAD_ERROR400, api.uploadCsar(file));
     }
 
     @Test


### PR DESCRIPTION
When uploading an invalid csar, command line always returned that a csar with same name already exists.
This PR fixes the issue (basically, removed the behaviour).
Note: When uploading the same csar twice, the server simply overwrites the old csar and will never complain that the csar already exists.