### PR TITLE
Improve cli logging in case of exceptions

### DIFF
--- a/cli/src/main/java/org/opentosca/toscana/cli/ApiController.java
+++ b/cli/src/main/java/org/opentosca/toscana/cli/ApiController.java
@@ -52,8 +52,7 @@ public class ApiController {
                 + Constants.ERROR_PLACEHOLDER, e.getMessage()));
             e.printStackTrace();
         } catch (TOSCAnaServerException e) {
-            System.err.println(String.format(SOMETHING_WRONG + Constants.CSAR_UPLOAD_RESPONSE_ERROR
-                + Constants.SERVER_ERROR_PLACEHOLDER, e.getStatusCode(), e.getErrorResponse().getMessage()));
+            e.print();
         }
         return "";
     }

--- a/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/TOSCAnaAPI.java
+++ b/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/TOSCAnaAPI.java
@@ -93,8 +93,7 @@ public class TOSCAnaAPI {
         } else {
             logger.debug("Execution of the call was not successful");
             throwToscanaException(call, response);
-            //Dead code (used to prevent "Missing return statement" compilaton
-            //Error
+            //Dead code (used to prevent "Missing return statement" compilation error
             return null;
         }
     }
@@ -257,7 +256,7 @@ public class TOSCAnaAPI {
     ) throws TOSCAnaServerException, IOException {
         ResponseBody errorBody = response.errorBody();
         TOSCAnaServerException exception = new TOSCAnaServerException(
-            "Failed to execute HTTP Call " + call.request().url().toString(),
+            "Execution of HTTP call " + call.request().url() + " failed",
             errorBody == null || errorBody.contentLength() == 0 ?
                 null : objectMapper.readValue(errorBody.string(), ServerError.class),
             response.code()

--- a/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/model/LogEntry.java
+++ b/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/model/LogEntry.java
@@ -1,20 +1,25 @@
 package org.opentosca.toscana.retrofit.model;
 
+import java.time.Instant;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class LogEntry {
     private Long timestamp;
     private String level;
     private String message;
+    private long index;
 
     public LogEntry(
         @JsonProperty("timestamp") Long timestamp,
         @JsonProperty("level") String level,
-        @JsonProperty("message") String message
+        @JsonProperty("message") String message,
+        @JsonProperty("index") long index
     ) {
         this.timestamp = timestamp;
         this.level = level;
         this.message = message;
+        this.index = index;
     }
 
     @JsonProperty("timestamp")
@@ -30,5 +35,15 @@ public class LogEntry {
     @JsonProperty("message")
     public String getMessage() {
         return message;
+    }
+    
+    @JsonProperty("index")
+    public long getIndex() {
+        return index;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("  > %-26s %-7s %s", Instant.ofEpochMilli(timestamp), level, message);
     }
 }

--- a/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/model/ServerError.java
+++ b/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/model/ServerError.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.retrofit.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,7 +34,7 @@ public class ServerError {
     }
 
     public String getMessage() {
-        return message;
+        return message == null ? "" : message;
     }
 
     public Long getTimestamp() {
@@ -45,6 +46,6 @@ public class ServerError {
     }
 
     public List<LogEntry> getLogs() {
-        return logs;
+        return logs == null ? new ArrayList<>() : logs;
     }
 }

--- a/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/util/TOSCAnaServerException.java
+++ b/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/util/TOSCAnaServerException.java
@@ -3,8 +3,9 @@ package org.opentosca.toscana.retrofit.util;
 import org.opentosca.toscana.retrofit.model.ServerError;
 
 public class TOSCAnaServerException extends Exception {
-    private ServerError errorResponse;
-    private int statusCode;
+   
+    private final ServerError errorResponse;
+    private final int statusCode;
 
     public TOSCAnaServerException(
         String message,
@@ -22,5 +23,11 @@ public class TOSCAnaServerException extends Exception {
 
     public int getStatusCode() {
         return statusCode;
+    }
+
+    public void print() {
+        System.err.printf("%s: %s%n", getMessage(), getStatusCode());
+        System.err.printf("%s: %s%n", getErrorResponse().getException(), getErrorResponse().getMessage());
+        errorResponse.getLogs().stream().forEach(System.err::println);
     }
 }

--- a/retrofit-wrapper/src/test/java/org/opentosca/toscana/retrofit/api/ResponseTest.java
+++ b/retrofit-wrapper/src/test/java/org/opentosca/toscana/retrofit/api/ResponseTest.java
@@ -13,6 +13,7 @@ import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -47,7 +48,7 @@ public class ResponseTest extends BaseTOSCAnaAPITest {
         } catch (TOSCAnaServerException e) {
             assertEquals(400, ((TOSCAnaServerException) e).getStatusCode());
             ServerError error = ((TOSCAnaServerException) e).getErrorResponse();
-            assertNull(error.getMessage());
+            assertSame("", error.getMessage());
             return;
         }
         fail();

--- a/server/src/main/java/org/opentosca/toscana/core/csar/CsarImpl.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/CsarImpl.java
@@ -86,5 +86,10 @@ public class CsarImpl implements Csar {
             this.transformations.put(transformation.getPlatform().id, transformation);
         }
     }
+
+    @Override
+    public String toString() {
+        return String.format("Csar [id: %s]", getIdentifier());
+    }
 }
 

--- a/server/src/main/java/org/opentosca/toscana/core/parse/CsarParseServiceImpl.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/CsarParseServiceImpl.java
@@ -9,27 +9,27 @@ import org.opentosca.toscana.model.EffectiveModel;
 import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.eclipse.winery.yaml.common.reader.yaml.Reader;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CsarParseServiceImpl implements CsarParseService {
 
-    private final static Logger logger = LoggerFactory.getLogger(CsarParseServiceImpl.class);
+    private Logger logger;
 
     @Autowired
     private CsarDao csarDao;
 
     @Override
     public EffectiveModel parse(Csar csar) throws InvalidCsarException {
+        logger = csar.getLog().getLogger(getClass());
         Reader reader = new Reader();
         File entryPoint = findEntryPoint(csar);
         TServiceTemplate serviceTemplate;
         try {
             serviceTemplate = reader.parse(entryPoint.getParent(), entryPoint.getName());
         } catch (Exception e) {
-            logger.info("An error occured while parsing csar '{}'", csar, e);
+            logger.warn("An error occured while parsing csar '{}'", csar, e);
             throw new InvalidCsarException(csar.getLog());
         }
         ModelConverter converter = new ModelConverter();
@@ -49,13 +49,13 @@ public class CsarParseServiceImpl implements CsarParseService {
         File[] entryPoints = content.listFiles((file, s) -> s.matches(".*\\.ya?ml$"));
         if (entryPoints.length == 1) {
             File entryPoint = entryPoints[0].getAbsoluteFile();
-            logger.info("detected entry point of csar '{}' is '{}'", csar.getIdentifier(), entryPoint.getAbsolutePath());
+            logger.warn("detected entry point of csar '{}' is '{}'", csar.getIdentifier(), entryPoint.getAbsolutePath());
             return entryPoint;
         } else if (entryPoints.length > 1) {
-            logger.info("parsing failed: more than one top level yaml file encountered in given csar");
+            logger.warn("parsing failed: more than one top level yaml file encountered in given csar");
             throw new InvalidCsarException(csar.getLog());
         } else {
-            logger.info("parsing failed: no top level yaml file encountered in given csar");
+            logger.error("parsing failed: no top level yaml file encountered in given csar");
             throw new InvalidCsarException(csar.getLog());
         }
     }


### PR DESCRIPTION
- Fix ParseService: Logs now to csar's log
- Fix cli/retrofit: In case of upload of an invalid csar, logging output is much more verbose (stacktraces are printed)

## Before
```
$ toscana csar upload -f dockerapp_missing.csar       

Something went wrong while uploading Csar: 400 null
```
## After
```
$ toscana csar upload -f dockerapp_missing.csar

Execution of HTTP call http://localhost:8084/api/csars/dockerapp_missing.csar failed
org.opentosca.toscana.core.parse.InvalidCsarException: 
  > 2017-11-30T00:45:25.868Z   WARN    detected entry point of csar 'dockerapp_missing' is '/home/heiko/.toscana/dockerapp_missing/content/template.yaml'
  > 2017-11-30T00:45:25.987Z   WARN    An error occured while parsing csar 'Csar [id: dockerapp_missing]'
  > 2017-11-30T00:45:25.987Z   WARN    org.eclipse.winery.yaml.common.exception.MultiException: protocol:type is null!
Context::INLINE = capability_types:SimplePublicWebEndpoint:properties:protocol
null


port:type is null!
Context::INLINE = capability_types:SimplePublicWebEndpoint:properties:port
null


network_name:type is null!
Context::INLINE = capability_types:SimplePublicWebEndpoint:properties:network_name
null


url_path:type is null!
Context::INLINE = capability_types:SimplePublicWebEndpoint:properties:url_path
null


endpoint:type is null!
Context::INLINE = topology_template:outputs:endpoint
null
/home/heiko/.toscana/dockerapp_missing/content/template.yaml
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.validator.support.ExceptionVisitor.setException(ExceptionVisitor.java:27)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.validator.TypeValidator.validatePropertyOrAttributeDefinition(TypeValidator.java:82)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.validator.TypeValidator.visit(TypeValidator.java:191)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.validator.TypeValidator.visit(TypeValidator.java:43)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.TPropertyDefinition.accept(TPropertyDefinition.java:181)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor.lambda$visitElement$5(AbstractVisitor.java:375)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1691)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:479)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor.visitElement(AbstractVisitor.java:377)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor.visit(AbstractVisitor.java:116)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.TEntityType.accept(TEntityType.java:152)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.TCapabilityType.accept(TCapabilityType.java:72)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor.lambda$visitElement$5(AbstractVisitor.java:375)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1691)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:479)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor.visitElement(AbstractVisitor.java:377)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.model.tosca.yaml.visitor.AbstractVisitor.visit(AbstractVisitor.java:303)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.validator.TypeValidator.validate(TypeValidator.java:58)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.validator.Validator.validate(Validator.java:40)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.reader.yaml.Reader.readServiceTemplate(Reader.java:141)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.eclipse.winery.yaml.common.reader.yaml.Reader.parse(Reader.java:44)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.opentosca.toscana.core.parse.CsarParseServiceImpl.parse(CsarParseServiceImpl.java:30)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.opentosca.toscana.core.csar.CsarServiceImpl.populateWithTemplate(CsarServiceImpl.java:46)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.opentosca.toscana.core.csar.CsarServiceImpl.submitCsar(CsarServiceImpl.java:34)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.opentosca.toscana.core.api.CsarController.uploadCSAR(CsarController.java:187)
  > 2017-11-30T00:45:25.988Z   WARN    	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  > 2017-11-30T00:45:25.988Z   WARN    	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  > 2017-11-30T00:45:25.988Z   WARN    	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.lang.reflect.Method.invoke(Method.java:498)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:133)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:97)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:827)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:738)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:85)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:967)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:901)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:970)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:872)
  > 2017-11-30T00:45:25.988Z   WARN    	at javax.servlet.http.HttpServlet.service(HttpServlet.java:661)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:846)
  > 2017-11-30T00:45:25.988Z   WARN    	at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.boot.web.filter.ApplicationContextHeaderFilter.doFilterInternal(ApplicationContextHeaderFilter.java:55)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.boot.actuate.trace.WebRequestTraceFilter.doFilterInternal(WebRequestTraceFilter.java:110)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:99)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.HttpPutFormContentFilter.doFilterInternal(HttpPutFormContentFilter.java:108)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.HiddenHttpMethodFilter.doFilterInternal(HiddenHttpMethodFilter.java:81)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:197)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.boot.actuate.autoconfigure.MetricsFilter.doFilterInternal(MetricsFilter.java:106)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:478)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:80)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:799)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:868)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1457)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  > 2017-11-30T00:45:25.988Z   WARN    	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
  > 2017-11-30T00:45:25.988Z   WARN    	at java.lang.Thread.run(Thread.java:748)
```