### PR TITLE
Implement docker imagetag persistency

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/CsarFilesystemDao.java
@@ -30,6 +30,10 @@ import org.springframework.stereotype.Repository;
 public class CsarFilesystemDao implements CsarDao {
 
     /**
+     The name of the directory which contains all csars
+     */
+    public final static String CSARS_DIR = "csars";
+    /**
      the name of the directory which contains the transformations
      */
     public final static String TRANSFORMATION_DIR = "transformations";
@@ -48,7 +52,7 @@ public class CsarFilesystemDao implements CsarDao {
 
     @Autowired
     public CsarFilesystemDao(Preferences preferences, @Lazy TransformationDao transformationDao) {
-        this.dataDir = preferences.getDataDir();
+        this.dataDir = new File(preferences.getDataDir(), CSARS_DIR);
         this.transformationDao = transformationDao;
 
         if (!dataDir.exists()) {

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
@@ -222,12 +222,7 @@ public class BaseImageMapper {
      Downloads the tags for a given base image
      */
     private List<ImageTags> fetchImageTags(DockerBaseImages image) {
-        String registryUrl = image.getRegistry();
-        Retrofit retrofit = new Retrofit.Builder()
-            .baseUrl(registryUrl)
-            .addConverterFactory(JacksonConverterFactory.create())
-            .build();
-        DockerRegistry registry = new DockerRegistry(registryUrl, retrofit);
+        DockerRegistry registry = new DockerRegistry(image.getRegistry());
         return registry.getTagsForRepository(image.getUsername(), image.getRepository());
     }
 

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
@@ -1,5 +1,11 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,6 +16,7 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 
 import org.opentosca.toscana.core.Profiles;
+import org.opentosca.toscana.core.util.Preferences;
 import org.opentosca.toscana.model.capability.OsCapability;
 import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.DockerRegistry;
 import org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model.Image;
@@ -25,6 +32,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 
 /**
  This class allows the mapping of OsCapabilities (from a tosca model) to a docker base image.
@@ -38,10 +47,17 @@ import org.springframework.stereotype.Service;
 @SuppressWarnings("ConstantConditions")
 public class BaseImageMapper {
 
+    public static final String DOCKER_IMAGE_DIR = "misc/docker-imagetags";
     private static final Logger logger = LoggerFactory.getLogger(BaseImageMapper.class);
 
+    private final File dataDir;
+    private final File imageTagsFile;
+    private final File lastUpdateFile;
+
+    private List<ImageTags> imageTags;
+
     /**
-     Stores the update intervall for the base Image mappings (in hours)
+     Stores the update interval for the base Image mappings (in hours)
      Taken from the property value:
      <code>toscana.docker.base-image-mapper.update-interval</code>
      */
@@ -66,9 +82,39 @@ public class BaseImageMapper {
     private MapperEngine engine;
 
     @Autowired
-    public BaseImageMapper(DockerBaseImages[] dockerBaseImages) {
+    public BaseImageMapper(DockerBaseImages[] dockerBaseImages, Preferences preferences) {
         this.baseImages = dockerBaseImages;
         engine = new MapperEngine(imageMap);
+        dataDir = new File(preferences.getDataDir(), DOCKER_IMAGE_DIR);
+        dataDir.mkdirs();
+        imageTagsFile = new File(dataDir, "image_tags");
+        lastUpdateFile = new File(dataDir, "last_update");
+        deserializeTags();
+
+    }
+
+    private void deserializeTags() {
+        try {
+            if (imageTagsFile.exists()) {
+                ObjectInputStream ois = new ObjectInputStream(new FileInputStream(imageTagsFile));
+                Object o = ois.readObject();
+                ois.close();
+                if (o instanceof List) {
+                    imageTags = (List<ImageTags>) o;
+                } else {
+                    logger.warn("File '{}' contained wrong data. Deleting file", imageTagsFile);
+                }
+            }
+            if (lastUpdateFile.exists()) {
+                ObjectInputStream ois = new ObjectInputStream(new FileInputStream(lastUpdateFile));
+                lastUpdate = ois.readLong();
+                ois.close();
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            logger.warn("Failed to deserialize docker tag information from disk. Removing files", e);
+            imageTagsFile.delete();
+            lastUpdateFile.delete();
+        }
     }
 
     /**
@@ -86,20 +132,48 @@ public class BaseImageMapper {
         logger.info("Updating BaseImage Mappings");
         for (DockerBaseImages baseImage : baseImages) {
             logger.debug("Fetching tags for base image {}", baseImage.name());
-            List<ImageTags> tags = fetchImageTags(baseImage);
-            if (tags != null) {
-                addImagesForType(baseImage, tags);
+            if (imageTags == null) {
+                imageTags = fetchImageTags(baseImage);
+                persistTags(imageTags);
+            }
+            if (imageTags != null) {
+                logger.debug("Remapping Tags for Base image {}", baseImage.name());
+                addImagesForType(baseImage, imageTags);
             }
         }
-        lastUpdate = System.currentTimeMillis();
+        setLastUpdateNow();
         logger.info("Mappings have been updated. The next update will be executed in approx. {} hours", updateInterval);
     }
 
+    private void persistTags(List<ImageTags> tags) {
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(imageTagsFile));
+            oos.writeObject(tags);
+            oos.close();
+        } catch (IOException e) {
+            logger.warn("Failed to write most recent docker image tags to file '{}", imageTagsFile, e);
+        }
+
+    }
+
+    private void setLastUpdateNow() {
+        lastUpdate = System.currentTimeMillis();
+        try {
+            lastUpdateFile.delete();
+            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(lastUpdateFile));
+            oos.writeLong(lastUpdate);
+            oos.close();
+        } catch (IOException e) {
+            logger.warn("Failed to write most recent update time of docker image tags to file '{}", lastUpdateFile, e);
+        }
+    }
+
+
     /**
-     This is the spring scheduled job used to perform the updates after the frist one
+     This is the spring scheduled job used to perform the updates on a regular basis
      <p>
      This method gets called every 10 minutes and if the Current timestamp is larger than the old one plus the time
-     perion
+     period
      it triggers a update of the mapping tables
      */
     @Scheduled(fixedRate = 600000)
@@ -115,7 +189,6 @@ public class BaseImageMapper {
      in the <code>model</code> package
      */
     private void addImagesForType(DockerBaseImages baseImage, List<ImageTags> pages) {
-        logger.debug("Remapping Tags for Base image {}", baseImage.name());
         List<DockerImageTag> tagList = new ArrayList<>();
         for (ImageTags page : pages) {
             for (ImageTag imageTag : page.getImageTags()) {
@@ -149,13 +222,18 @@ public class BaseImageMapper {
      Downloads the tags for a given base image
      */
     private List<ImageTags> fetchImageTags(DockerBaseImages image) {
-        DockerRegistry registry = new DockerRegistry(image.getRegistry());
+        String registryUrl = image.getRegistry();
+        Retrofit retrofit = new Retrofit.Builder()
+            .baseUrl(registryUrl)
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build();
+        DockerRegistry registry = new DockerRegistry(registryUrl, retrofit);
         return registry.getTagsForRepository(image.getUsername(), image.getRepository());
     }
 
     /**
      This method attempts to map a OsCapability to a docker base image.
-     If the mapping fails a UnsopportedOperationException is thrown. Reasons for failiure are: Invalid Architecture,
+     If the mapping fails a UnsupportedOperationException is thrown. Reasons for failure are: Invalid Architecture,
      Unsupported type, Unknown version...
      */
     public String mapToBaseImage(OsCapability capability) {

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/BaseImageMapper.java
@@ -32,8 +32,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import retrofit2.Retrofit;
-import retrofit2.converter.jackson.JacksonConverterFactory;
 
 /**
  This class allows the mapping of OsCapabilities (from a tosca model) to a docker base image.
@@ -103,6 +101,7 @@ public class BaseImageMapper {
                     imageTags = (List<ImageTags>) o;
                 } else {
                     logger.warn("File '{}' contained wrong data. Deleting file", imageTagsFile);
+                    imageTagsFile.delete();
                 }
             }
             if (lastUpdateFile.exists()) {

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperEngine.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperEngine.java
@@ -1,7 +1,6 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -24,10 +23,10 @@ import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperUtils
  */
 class MapperEngine {
 
-    private final Map<String, DockerImage> imageMap;
+    TagBase tagBase;
 
-    public MapperEngine(Map<String, DockerImage> imageMap) {
-        this.imageMap = imageMap;
+    public MapperEngine(TagBase tagBase) {
+        this.tagBase = tagBase;
     }
 
     /**
@@ -64,7 +63,7 @@ class MapperEngine {
                 tag = "latest";
             } else {
                 String version = capability.getVersion().get();
-                DockerImage img = imageMap.get(distro);
+                DockerImage img = tagBase.get(distro);
                 Optional<DockerImageTag> imgTag = img.findTagByName(version);
                 if (imgTag.isPresent()) {
                     tag = imgTag.get().getName();
@@ -167,7 +166,7 @@ class MapperEngine {
      Perfoms the mapping to the base image
      */
     private String performMapping(OsCapability capability, String tag, String distro) {
-        DockerImage img = imageMap.get(distro);
+        DockerImage img = tagBase.get(distro);
         String architecture = getCapabilityArchitecture(capability)
             .orElseThrow(() -> new UnsupportedOperationException("Architecture not supported!"));
 
@@ -191,7 +190,7 @@ class MapperEngine {
     private boolean hasKnownDistributionName(OsCapability capability) {
         if (capability.getDistribution().isPresent()) {
             String distroName = convertDistributionName(capability);
-            DockerImage image = imageMap.get(distroName);
+            DockerImage image = tagBase.get(distroName);
             return image != null;
         }
         return false;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperEngine.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperEngine.java
@@ -23,10 +23,10 @@ import static org.opentosca.toscana.plugins.kubernetes.docker.mapper.MapperUtils
  */
 class MapperEngine {
 
-    TagBase tagBase;
+    TagStorage tagStorage;
 
-    public MapperEngine(TagBase tagBase) {
-        this.tagBase = tagBase;
+    public MapperEngine(TagStorage tagStorage) {
+        this.tagStorage = tagStorage;
     }
 
     /**
@@ -63,7 +63,7 @@ class MapperEngine {
                 tag = "latest";
             } else {
                 String version = capability.getVersion().get();
-                DockerImage img = tagBase.get(distro);
+                DockerImage img = tagStorage.get(distro);
                 Optional<DockerImageTag> imgTag = img.findTagByName(version);
                 if (imgTag.isPresent()) {
                     tag = imgTag.get().getName();
@@ -166,7 +166,7 @@ class MapperEngine {
      Perfoms the mapping to the base image
      */
     private String performMapping(OsCapability capability, String tag, String distro) {
-        DockerImage img = tagBase.get(distro);
+        DockerImage img = tagStorage.get(distro);
         String architecture = getCapabilityArchitecture(capability)
             .orElseThrow(() -> new UnsupportedOperationException("Architecture not supported!"));
 
@@ -190,7 +190,7 @@ class MapperEngine {
     private boolean hasKnownDistributionName(OsCapability capability) {
         if (capability.getDistribution().isPresent()) {
             String distroName = convertDistributionName(capability);
-            DockerImage image = tagBase.get(distroName);
+            DockerImage image = tagStorage.get(distroName);
             return image != null;
         }
         return false;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/TagBase.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/TagBase.java
@@ -1,0 +1,109 @@
+package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opentosca.toscana.core.util.Preferences;
+import org.opentosca.toscana.plugins.kubernetes.docker.mapper.model.DockerImage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TagBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(TagBase.class);
+
+    private static final String DOCKER_IMAGE_TAGS = "misc/docker-tagbase.json";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+
+    private final File file;
+    
+    private TagBaseData data = new TagBaseData();
+    
+    /**
+     Stores the update interval for the base Image mappings (in hours)
+     Taken from the property value:
+     <code>toscana.docker.base-image-mapper.update-interval</code>
+     */
+    @Value("${toscana.docker.base-image-mapper.update-interval}")
+    private int updateInterval;
+
+    public TagBase(@Autowired Preferences preferences) {
+        this.file = new File(preferences.getDataDir(), DOCKER_IMAGE_TAGS);
+        file.getParentFile().mkdirs();
+        if (file.exists()) {
+            load();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void load() {
+        try {
+            data = MAPPER.readValue(file, TagBaseData.class);
+        } catch (IOException | ClassCastException e) {
+            logger.error("Failed to read from '{}'. Deleting file", file, e);
+            file.delete();
+        }
+    }
+
+    void update() {
+        data.lastUpdateTime = System.currentTimeMillis();
+        persist();
+        logger.info("Mappings saved to disk. Next update in approx. {} hours", updateInterval);
+    }
+
+    private void persist() {
+        try {
+            MAPPER.writeValue(file, data);
+        } catch (IOException e) {
+            logger.error("Failed to serialize docker tag base to file '{}'", file, e);
+        }
+    }
+
+    boolean needsUpdate() {
+        long currentTime = System.currentTimeMillis();
+        long updateIntervalExceeds = data.lastUpdateTime + updateInterval * 3600 * 1000;
+        return currentTime >= updateIntervalExceeds;
+    }
+
+    /**
+     Returns a point in time when the next update is due.
+     */
+    Instant getNextUpdate() {
+        Duration updateIntervalDuration = Duration.ofHours(updateInterval);
+        return Instant.ofEpochMilli(data.lastUpdateTime).plus(updateIntervalDuration);
+    }
+
+    public DockerImage get(String distro) {
+        return data.map.get(distro);
+    }
+   
+    public DockerImage put(String distro, DockerImage image) {
+        return data.map.put(distro, image);
+    }
+
+    public int size() {
+        return data.map.size();
+    }
+
+    public void putAll(Map<String, DockerImage> imageMap) {
+        data.map.putAll(imageMap);
+    }
+    
+    private static class TagBaseData {
+        
+        public long lastUpdateTime = 0;
+        public final Map<String, DockerImage> map = new HashMap<>();
+    }
+
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/TagStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/TagStorage.java
@@ -38,7 +38,7 @@ public class TagStorage {
      Taken from the property value:
      <code>toscana.docker.base-image-mapper.persist-interval</code>
      */
-    @Value("${toscana.docker.base-image-mapper.persist-interval}")
+    @Value("${toscana.docker.base-image-mapper.update-interval}")
     private int updateInterval;
 
     public TagStorage(@Autowired Preferences preferences) {

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
@@ -34,7 +34,7 @@ public class DockerRegistry {
      Helper method to initilialize retrofit
      */
     private void initRetrofit(String url) {
-        logger.debug("Initializing Retrofit for Registry {}", url);
+        logger.trace("Initializing Retrofit for Registry {}", url);
         Retrofit retrofit = new Retrofit.Builder()
             .baseUrl(url)
             .addConverterFactory(JacksonConverterFactory.create())
@@ -70,7 +70,7 @@ public class DockerRegistry {
                     logger.error("Printing error response failed.", ex);
                     ex.printStackTrace();
                 }
-                return null;
+                return imageTags;
             }
         } while (next != null);
         return imageTags;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/Image.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/Image.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Image {
+public class Image implements Serializable {
 
     @JsonProperty("architecture")
     private String architecture;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/Image.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/Image.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Image implements Serializable {
+public class Image {
 
     @JsonProperty("architecture")
     private String architecture;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTag.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTag.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ImageTag implements Serializable {
+public class ImageTag {
 
     @JsonProperty("name")
     private String name;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTag.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTag.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ImageTag {
+public class ImageTag implements Serializable {
 
     @JsonProperty("name")
     private String name;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTags.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTags.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper.api.model;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ImageTags {
+public class ImageTags implements Serializable {
 
     @JsonProperty("next")
     private Object next;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTags.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/model/ImageTags.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  Only the needed fields get stored in a attribute. the rest is put into the AdditionalProperties map
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ImageTags implements Serializable {
+public class ImageTags {
 
     @JsonProperty("next")
     private Object next;

--- a/server/src/test/java/org/opentosca/toscana/core/BaseJUnitTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/BaseJUnitTest.java
@@ -25,13 +25,13 @@ public abstract class BaseJUnitTest extends BaseTest {
      */
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder(PROJECT_ROOT);
-    private static final String STASIC_TMPDIR = "testsuite-tmpdir-static";
+    private static final String STATIC_TMPDIR = "testsuite-tmpdir-static";
     protected File tmpdir;
     protected static File staticTmpDir;
     
     @BeforeClass
     public final static void offerStaticTmpDir() throws IOException {
-        staticTmpDir = new File(PROJECT_ROOT, STASIC_TMPDIR);
+        staticTmpDir = new File(PROJECT_ROOT, STATIC_TMPDIR);
         FileUtils.deleteDirectory(staticTmpDir);
         staticTmpDir.mkdir();
     }

--- a/server/src/test/java/org/opentosca/toscana/core/BaseJUnitTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/BaseJUnitTest.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.core.testutils.CategoryAwareJUnitRunner;
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -18,15 +19,22 @@ import org.junit.runner.RunWith;
 @RunWith(CategoryAwareJUnitRunner.class)
 public abstract class BaseJUnitTest extends BaseTest {
 
-    public static final File PROJECT_ROOT = new File(System.getProperty("user.dir"));
 
     /**
      Grants disk access. Is reset before every test method.
      */
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder(PROJECT_ROOT);
-    // "user.dir" is module root
-    public File tmpdir;
+    private static final String STASIC_TMPDIR = "testsuite-tmpdir-static";
+    protected File tmpdir;
+    protected static File staticTmpDir;
+    
+    @BeforeClass
+    public final static void offerStaticTmpDir() throws IOException {
+        staticTmpDir = new File(PROJECT_ROOT, STASIC_TMPDIR);
+        FileUtils.deleteDirectory(staticTmpDir);
+        staticTmpDir.mkdir();
+    }
 
     @Before
     public final void initTmpdir() throws IOException {
@@ -39,5 +47,10 @@ public abstract class BaseJUnitTest extends BaseTest {
         for (File file : files) {
             FileUtils.deleteDirectory(file);
         }
+    }
+    
+    @AfterClass
+    public final static void cleanupStaticTmpDir() throws IOException {
+        FileUtils.deleteDirectory(staticTmpDir);
     }
 }

--- a/server/src/test/java/org/opentosca/toscana/core/BaseSpringTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/BaseSpringTest.java
@@ -10,7 +10,9 @@ import org.opentosca.toscana.core.util.Preferences;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +32,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource("classpath:test-properties.yml")
 public abstract class BaseSpringTest extends BaseTest {
 
-    private final static Logger logger = LoggerFactory.getLogger(BaseSpringTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(BaseSpringTest.class);
 
     protected File tmpdir;
     @Autowired
@@ -46,6 +48,7 @@ public abstract class BaseSpringTest extends BaseTest {
         tmpdir = preferences.getDataDir();
     }
 
+    
     @Before
     public final void startupPrepareDisk() throws IOException {
         FileUtils.deleteDirectory(tmpdir);
@@ -58,4 +61,5 @@ public abstract class BaseSpringTest extends BaseTest {
         FileUtils.deleteDirectory(tmpdir);
         logger.info("Cleaned up disk");
     }
+    
 }

--- a/server/src/test/java/org/opentosca/toscana/core/BaseTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/BaseTest.java
@@ -1,5 +1,7 @@
 package org.opentosca.toscana.core;
 
+import java.io.File;
+
 import org.opentosca.toscana.core.testutils.TestCategories;
 import org.opentosca.toscana.core.testutils.TestCategory;
 
@@ -11,6 +13,9 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles( {Profiles.EXCLUDE_BASE_IMAGE_MAPPER})
 @TestCategory(value = TestCategories.FAST)
 public abstract class BaseTest {
+
+    // "user.dir" is module root
+    protected static final File PROJECT_ROOT = new File(System.getProperty("user.dir"));
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();

--- a/server/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/csar/CsarFilesystemDaoTest.java
@@ -39,6 +39,7 @@ public class CsarFilesystemDaoTest extends BaseJUnitTest {
     private Preferences preferences;
     @Mock
     private Log fakeLog;
+    private File generalCsarsDir;
 
     @Before
     public void setUp() {
@@ -47,6 +48,7 @@ public class CsarFilesystemDaoTest extends BaseJUnitTest {
         transformationDao = mock(TransformationDao.class);
         csarDao = new CsarFilesystemDao(preferences, transformationDao);
         csarDao.init();
+        generalCsarsDir = new File(tmpdir, CsarFilesystemDao.CSARS_DIR);
     }
 
     @Test
@@ -55,7 +57,7 @@ public class CsarFilesystemDaoTest extends BaseJUnitTest {
         File csarFile = TestCsars.CSAR_YAML_VALID_DOCKER_SIMPLETASK;
         InputStream csarStream = new FileInputStream(csarFile);
         csarDao.create(identifier, csarStream);
-        File csarFolder = new File(tmpdir, identifier);
+        File csarFolder = new File(generalCsarsDir, identifier);
         File contentFolder = new File(csarFolder, CsarFilesystemDao.CONTENT_DIR);
         File transformationFolder = new File(csarFolder, CsarFilesystemDao.TRANSFORMATION_DIR);
         assertTrue(contentFolder.isDirectory());
@@ -67,7 +69,7 @@ public class CsarFilesystemDaoTest extends BaseJUnitTest {
     public void deleteCsarRemovesDataOnDisk() throws Exception {
         String identifier = createFakeCsarDirectories(1)[0];
         csarDao.delete(identifier);
-        File csarDir = new File(tmpdir, identifier);
+        File csarDir = new File(generalCsarsDir, identifier);
         assertFalse(csarDir.exists());
     }
     
@@ -127,7 +129,7 @@ public class CsarFilesystemDaoTest extends BaseJUnitTest {
         String[] identifiers = new String[10];
         for (int i = 0; i < numberOfCsars; i++) {
             identifiers[i] = "test" + i;
-            File fakeApp = new File(tmpdir, identifiers[i]);
+            File fakeApp = new File(generalCsarsDir, identifiers[i]);
             fakeApp.mkdir();
             File fakeContentDir = new File(fakeApp, CsarFilesystemDao.CONTENT_DIR);
             fakeContentDir.mkdir();
@@ -146,7 +148,7 @@ public class CsarFilesystemDaoTest extends BaseJUnitTest {
         createFakeCsarDirectories(numberOfCsars);
         // create some random file in data_dir
         String simpleFileName = "randomFile";
-        File randomFile = new File(tmpdir, simpleFileName);
+        File randomFile = new File(generalCsarsDir, simpleFileName);
         randomFile.createNewFile();
 
         csarDao = new CsarFilesystemDao(preferences, transformationDao);

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
@@ -3,6 +3,7 @@ package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
 import java.util.Map;
 
 import org.opentosca.toscana.core.integration.BaseIntegrationTest;
+import org.opentosca.toscana.core.util.Preferences;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -49,8 +50,8 @@ public class MapperLoaderTest extends BaseIntegrationTest {
         }
 
         @Bean
-        public BaseImageMapper getBaseImageMapper(@Autowired DockerBaseImages[] img) {
-            return new BaseImageMapper(img);
+        public BaseImageMapper getBaseImageMapper(@Autowired DockerBaseImages[] img, @Autowired Preferences preferences) {
+            return new BaseImageMapper(img, preferences);
         }
     }
 }

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
@@ -1,7 +1,5 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
 
-import java.util.Map;
-
 import org.opentosca.toscana.core.integration.BaseIntegrationTest;
 import org.opentosca.toscana.core.util.Preferences;
 
@@ -35,7 +33,7 @@ public class MapperLoaderTest extends BaseIntegrationTest {
             builder().distribution(DEBIAN).build()
         );
         logger.info("Performed a mapping to {}", image);
-        TagBase data = mapper.getTagBase();
+        TagStorage data = mapper.getTagStorage();
         assertEquals(DockerBaseImages.values().length, data.size());
     }
 
@@ -51,7 +49,7 @@ public class MapperLoaderTest extends BaseIntegrationTest {
 
         @Bean
         public BaseImageMapper getBaseImageMapper(@Autowired DockerBaseImages[] img, @Autowired Preferences preferences) {
-            return new BaseImageMapper(img, new TagBase(preferences));
+            return new BaseImageMapper(img, new TagStorage(preferences));
         }
     }
 }

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperLoaderTest.java
@@ -35,7 +35,7 @@ public class MapperLoaderTest extends BaseIntegrationTest {
             builder().distribution(DEBIAN).build()
         );
         logger.info("Performed a mapping to {}", image);
-        Map data = mapper.getImageMap();
+        TagBase data = mapper.getTagBase();
         assertEquals(DockerBaseImages.values().length, data.size());
     }
 
@@ -51,7 +51,7 @@ public class MapperLoaderTest extends BaseIntegrationTest {
 
         @Bean
         public BaseImageMapper getBaseImageMapper(@Autowired DockerBaseImages[] img, @Autowired Preferences preferences) {
-            return new BaseImageMapper(img, preferences);
+            return new BaseImageMapper(img, new TagBase(preferences));
         }
     }
 }

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.opentosca.toscana.core.BaseJUnitTest;
+import org.opentosca.toscana.core.util.Preferences;
 import org.opentosca.toscana.model.capability.OsCapability;
 import org.opentosca.toscana.model.capability.OsCapability.Distribution;
 import org.opentosca.toscana.plugins.kubernetes.docker.mapper.util.DataContainer;
@@ -20,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.opentosca.toscana.model.capability.OsCapability.Architecture.x86_64;
 import static org.opentosca.toscana.model.capability.OsCapability.Type.LINUX;
 import static org.opentosca.toscana.model.capability.OsCapability.builder;
@@ -65,11 +68,13 @@ public class MapperTest extends BaseJUnitTest {
             .getResourceAsStream("kubernetes/base-image-mapper/image-map.json");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(in, out);
+        Preferences preferences = mock(Preferences.class);
+        when(preferences.getDataDir()).thenReturn(staticTmpDir);
         BaseImageMapper baseImageMapper = new BaseImageMapper(new DockerBaseImages[] {
             ALPINE,
             DEBIAN,
             UBUNTU
-        });
+        }, preferences);
         DataContainer data = mapper.readValue(new String(out.toByteArray()), DataContainer.class);
 
         baseImageMapper.setImageMap(data.data);

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
@@ -70,12 +70,12 @@ public class MapperTest extends BaseJUnitTest {
         IOUtils.copy(in, out);
         Preferences preferences = mock(Preferences.class);
         when(preferences.getDataDir()).thenReturn(staticTmpDir);
-        TagBase tagBase = new TagBase(preferences);
+        TagStorage tagStorage = new TagStorage(preferences);
         BaseImageMapper baseImageMapper = new BaseImageMapper(new DockerBaseImages[] {
             ALPINE,
             DEBIAN,
             UBUNTU
-        }, tagBase);
+        }, tagStorage);
         DataContainer data = mapper.readValue(new String(out.toByteArray()), DataContainer.class);
 
         baseImageMapper.setImageMap(data.data);

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
@@ -70,11 +70,12 @@ public class MapperTest extends BaseJUnitTest {
         IOUtils.copy(in, out);
         Preferences preferences = mock(Preferences.class);
         when(preferences.getDataDir()).thenReturn(staticTmpDir);
+        TagBase tagBase = new TagBase(preferences);
         BaseImageMapper baseImageMapper = new BaseImageMapper(new DockerBaseImages[] {
             ALPINE,
             DEBIAN,
             UBUNTU
-        }, preferences);
+        }, tagBase);
         DataContainer data = mapper.readValue(new String(out.toByteArray()), DataContainer.class);
 
         baseImageMapper.setImageMap(data.data);


### PR DESCRIPTION
Decreases worst case startup time from around 20s to 3s.

- Change root dir for csars from `<datadir>` to `<datadir>/csars` (on disk)
in order to store other stuff in `<datadir>` aswell
- Serializes lastUpdate time and image tag list to disk.
After this patch, will only fetch image tags if not found
on disk or if update interval is exceeded