### PR TITLE
Fix/visitor pattern

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/model/EffectiveModel.java
+++ b/server/src/main/java/org/opentosca/toscana/model/EffectiveModel.java
@@ -10,8 +10,8 @@ import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultDirectedGraph;
 
 public class EffectiveModel {
-    
-    private final Graph<RootNode, RootRelationship> topology = 
+
+    private final Graph<RootNode, RootRelationship> topology =
         new DefaultDirectedGraph<RootNode, RootRelationship>(RootRelationship.class);
 
     public EffectiveModel(Set<RootNode> vertices) {

--- a/server/src/main/java/org/opentosca/toscana/model/RelationshipConstructor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/RelationshipConstructor.java
@@ -10,12 +10,13 @@ import org.opentosca.toscana.model.relation.RoutesTo;
 import org.opentosca.toscana.model.visitor.RelationshipVisitor;
 
 public class RelationshipConstructor implements RelationshipVisitor {
-    
+
     private final Requirement requirement;
-    
-    public RelationshipConstructor(Requirement requirement){
+
+    public RelationshipConstructor(Requirement requirement) {
         this.requirement = requirement;
     }
+
     @Override
     public void visit(RootRelationship relation) {
 

--- a/server/src/main/java/org/opentosca/toscana/model/capability/AdminEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AdminEndpointCapability.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.model.datatype.Port;
 import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -52,7 +53,7 @@ public class AdminEndpointCapability extends EndpointCapability {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/AdminEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AdminEndpointCapability.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -51,7 +50,7 @@ public class AdminEndpointCapability extends EndpointCapability {
 
     public static class AdminEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.BlockStorage;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -29,7 +30,7 @@ public class AttachmentCapability extends Capability {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
@@ -6,7 +6,6 @@ import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.BlockStorage;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -27,7 +26,7 @@ public class BindableCapability extends NodeCapability {
 
     public static class BindableCapabilityBuilder extends NodeCapabilityBuilder {
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -28,7 +29,7 @@ public class BindableCapability extends NodeCapability {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
@@ -6,8 +6,8 @@ import java.util.Set;
 import org.opentosca.toscana.model.DescribableEntity;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
-import org.opentosca.toscana.model.visitor.Visitable;
-import org.opentosca.toscana.model.visitor.Visitor;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
+import org.opentosca.toscana.model.visitor.VisitableCapability;
 
 import lombok.Builder;
 import lombok.Data;
@@ -19,7 +19,7 @@ import lombok.Singular;
  (TOSCA Simple Profile in YAML Version 1.1, p. 82)
  */
 @Data
-public class Capability extends DescribableEntity implements Visitable {
+public class Capability extends DescribableEntity implements VisitableCapability {
 
     /**
      Set of Node Class Types that are valid sources of any relationship established to this capability.
@@ -46,7 +46,7 @@ public class Capability extends DescribableEntity implements Visitable {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
@@ -10,7 +10,6 @@ import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.Min;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -130,7 +131,7 @@ public class ComputeCapability extends Capability {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -32,7 +33,7 @@ public class ContainerCapability extends ComputeCapability {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.model.datatype.Port;
 import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -48,7 +49,7 @@ public class DatabaseEndpointCapability extends EndpointCapability {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -109,7 +110,7 @@ public class DockerContainerCapability extends ContainerCapability {
     }
    
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
@@ -8,7 +8,6 @@ import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -108,7 +107,7 @@ public class DockerContainerCapability extends ContainerCapability {
 
     public static class DockerContainerCapabilityBuilder extends ContainerCapabilityBuilder {
     }
-   
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
@@ -12,6 +12,7 @@ import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.relation.ConnectsTo;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -168,7 +169,7 @@ public class EndpointCapability extends Capability {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
@@ -13,7 +13,6 @@ import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.relation.ConnectsTo;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -167,7 +166,7 @@ public class EndpointCapability extends Capability {
         TARGET,
         PEER
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -44,7 +45,7 @@ public class NetworkCapability extends Capability {
     }
    
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -43,7 +42,7 @@ public class NetworkCapability extends Capability {
 
     public static class NetworkCapabilityBuilder extends CapabilityBuilder {
     }
-   
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -27,7 +26,7 @@ public class NodeCapability extends Capability {
 
     public static class NodeCapabilityBuilder extends CapabilityBuilder {
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -28,7 +29,7 @@ public class NodeCapability extends Capability {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -116,7 +115,7 @@ public class OsCapability extends Capability {
 
     public static class OsCapabilityBuilder extends CapabilityBuilder {
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -117,7 +118,7 @@ public class OsCapability extends Capability {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
@@ -9,6 +9,7 @@ import org.opentosca.toscana.model.datatype.Port;
 import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -92,7 +93,7 @@ public class PublicEndpointCapability extends EndpointCapability {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
@@ -10,7 +10,6 @@ import org.opentosca.toscana.model.datatype.PortSpec;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -91,7 +90,7 @@ public class PublicEndpointCapability extends EndpointCapability {
 
     public static class PublicEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -67,7 +68,8 @@ public class ScalableCapability extends Capability {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
+        
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -69,7 +68,7 @@ public class ScalableCapability extends Capability {
 
     @Override
     public void accept(CapabilityVisitor v) {
-        
+
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.CapabilityVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -44,7 +45,7 @@ public class StorageCapability extends Capability {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
@@ -5,6 +5,7 @@ import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -49,7 +50,7 @@ public class Apache extends WebServer {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
@@ -6,7 +6,6 @@ import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.opentosca.toscana.model.capability.AttachmentCapability;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.opentosca.toscana.model.capability.AttachmentCapability;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -131,7 +132,7 @@ public class BlockStorage extends RootNode {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
@@ -16,7 +16,6 @@ import org.opentosca.toscana.model.datatype.PortInfo;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.AttachesTo;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -90,11 +89,11 @@ public class Compute extends RootNode {
     }
 
     /**
-     @param nodeName       {@link #nodeName}
-     @param adminEndpoint  {@link #adminEndpoint}
-     @param scalable       {@link #scalable}
-     @param binding        {@link #binding}
-     @param localStorage   {@link #localStorage}
+     @param nodeName      {@link #nodeName}
+     @param adminEndpoint {@link #adminEndpoint}
+     @param scalable      {@link #scalable}
+     @param binding       {@link #binding}
+     @param localStorage  {@link #localStorage}
      */
     public ComputeBuilder builder(String nodeName,
                                   AdminEndpointCapability adminEndpoint,
@@ -111,17 +110,19 @@ public class Compute extends RootNode {
 
 
     /**
-     @return {@link #privateAddress} */
+     @return {@link #privateAddress}
+     */
     public Optional<String> getPrivateAddress() {
         return Optional.ofNullable(privateAddress);
     }
 
     /**
-     @return {@link #publicAddress} */
+     @return {@link #publicAddress}
+     */
     public Optional<String> getPublicAddress() {
         return Optional.ofNullable(publicAddress);
     }
-    
+
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
@@ -15,6 +15,7 @@ import org.opentosca.toscana.model.datatype.NetworkInfo;
 import org.opentosca.toscana.model.datatype.PortInfo;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.AttachesTo;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -108,10 +109,6 @@ public class Compute extends RootNode {
             .localStorage(localStorage);
     }
 
-    @Override
-    public void accept(Visitor v) {
-        v.visit(this);
-    }
 
     /**
      @return {@link #privateAddress} */
@@ -123,6 +120,11 @@ public class Compute extends RootNode {
      @return {@link #publicAddress} */
     public Optional<String> getPublicAddress() {
         return Optional.ofNullable(publicAddress);
+    }
+    
+    @Override
+    public void accept(NodeVisitor v) {
+        v.visit(this);
     }
 }
 

--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
@@ -9,7 +9,7 @@ import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
-import org.opentosca.toscana.model.visitor.Visitor;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -80,7 +80,7 @@ public class ContainerApplication extends RootNode {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerRuntime.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerRuntime.java
@@ -6,7 +6,7 @@ import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.visitor.Visitor;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -57,7 +57,7 @@ public class ContainerRuntime extends SoftwareComponent {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Database.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Database.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/Database.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Database.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
 import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -131,7 +132,7 @@ public class Database extends RootNode {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Dbms.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Dbms.java
@@ -7,7 +7,6 @@ import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/server/src/main/java/org/opentosca/toscana/model/node/Dbms.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Dbms.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
@@ -79,7 +80,7 @@ public class Dbms extends SoftwareComponent {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
@@ -10,7 +10,6 @@ import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,9 +37,9 @@ public class DockerApplication extends ContainerApplication {
     }
 
     /**
-     @param nodeName  {@link #nodeName}
-     @param host      {@link #host}
-     @param network   {@link #network}
+     @param nodeName {@link #nodeName}
+     @param host     {@link #host}
+     @param network  {@link #network}
      */
     public static DockerApplicationBuilder builder(Requirement<DockerContainerCapability, ContainerRuntime, HostedOn> host,
                                                    String nodeName,

--- a/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
@@ -9,6 +9,7 @@ import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
@@ -51,7 +52,7 @@ public class DockerApplication extends ContainerApplication {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
@@ -10,6 +10,7 @@ import org.opentosca.toscana.model.capability.Requirement.RequirementBuilder;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.RoutesTo;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -69,7 +70,7 @@ public class LoadBalancer extends RootNode {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
@@ -11,7 +11,6 @@ import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.RoutesTo;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
@@ -6,7 +6,6 @@ import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
@@ -5,6 +5,7 @@ import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
 import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
@@ -52,7 +53,7 @@ public class MysqlDatabase extends Database {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
@@ -5,7 +5,6 @@ import org.opentosca.toscana.model.capability.ContainerCapability.ContainerCapab
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
@@ -4,6 +4,7 @@ import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability.ContainerCapabilityBuilder;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -55,7 +56,7 @@ public class MysqlDbms extends Dbms {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
@@ -8,7 +8,6 @@ import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
@@ -7,6 +7,7 @@ import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -61,7 +62,7 @@ public class Nodejs extends WebServer {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -88,7 +89,7 @@ public class ObjectStorage extends RootNode {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
@@ -11,8 +11,8 @@ import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.DependsOn;
-import org.opentosca.toscana.model.visitor.Visitable;
-import org.opentosca.toscana.model.visitor.Visitor;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
+import org.opentosca.toscana.model.visitor.VisitableNode;
 
 import lombok.Builder;
 import lombok.Data;
@@ -21,7 +21,7 @@ import lombok.Data;
  The base node. Every other node will derive from this class.
  */
 @Data
-public class RootNode extends DescribableEntity implements Visitable {
+public class RootNode extends DescribableEntity implements VisitableNode {
 
     protected final Set<Requirement> requirements = new HashSet<>();
     protected final Set<Capability> capabilities = new HashSet<>();
@@ -66,7 +66,7 @@ public class RootNode extends DescribableEntity implements Visitable {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -83,7 +84,7 @@ public class SoftwareComponent extends RootNode {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -75,7 +76,7 @@ public class WebApplication extends RootNode {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
@@ -7,6 +7,7 @@ import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
@@ -71,7 +72,7 @@ public class WebServer extends SoftwareComponent {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
@@ -8,7 +8,6 @@ import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
@@ -10,7 +10,6 @@ import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.ConnectsTo;
 import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
@@ -9,6 +9,7 @@ import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.ConnectsTo;
 import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -82,7 +83,7 @@ public class WordPress extends WebApplication {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(NodeVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/AttachesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/AttachesTo.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Size;
 
 import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.node.Compute;
+import org.opentosca.toscana.model.visitor.RelationshipVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Data;
@@ -61,7 +62,7 @@ public class AttachesTo extends RootRelationship {
 
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/AttachesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/AttachesTo.java
@@ -7,7 +7,6 @@ import javax.validation.constraints.Size;
 import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.visitor.RelationshipVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Data;
 

--- a/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
@@ -3,6 +3,7 @@ package org.opentosca.toscana.model.relation;
 import java.util.Optional;
 
 import org.opentosca.toscana.model.datatype.Credential;
+import org.opentosca.toscana.model.visitor.RelationshipVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -39,7 +40,7 @@ public class ConnectsTo extends RootRelationship {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.visitor.RelationshipVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.relation;
 
+import org.opentosca.toscana.model.visitor.RelationshipVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -20,7 +21,7 @@ public class DependsOn extends RootRelationship {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
@@ -1,7 +1,6 @@
 package org.opentosca.toscana.model.relation;
 
 import org.opentosca.toscana.model.visitor.RelationshipVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -19,7 +18,7 @@ public class DependsOn extends RootRelationship {
 
     public static class DependsOnBuilder extends RootRelationshipBuilder {
     }
-    
+
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
@@ -1,7 +1,6 @@
 package org.opentosca.toscana.model.relation;
 
 import org.opentosca.toscana.model.visitor.RelationshipVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;
@@ -20,7 +19,7 @@ public class HostedOn extends RootRelationship {
 
     public static class HostedOnBuilder extends RootRelationshipBuilder {
     }
-    
+
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.relation;
 
+import org.opentosca.toscana.model.visitor.RelationshipVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -21,7 +22,7 @@ public class HostedOn extends RootRelationship {
     }
     
     @Override
-    public void accept(Visitor v) {
+    public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
@@ -1,8 +1,8 @@
 package org.opentosca.toscana.model.relation;
 
 import org.opentosca.toscana.model.DescribableEntity;
-import org.opentosca.toscana.model.visitor.Visitable;
-import org.opentosca.toscana.model.visitor.Visitor;
+import org.opentosca.toscana.model.visitor.RelationshipVisitor;
+import org.opentosca.toscana.model.visitor.VisitableRelationship;
 
 import lombok.Builder;
 import lombok.Data;
@@ -12,7 +12,7 @@ import lombok.Data;
  (TOSCA Simple Profile in YAML Version 1.1, p. 159)
  */
 @Data
-public class RootRelationship extends DescribableEntity implements Visitable {
+public class RootRelationship extends DescribableEntity implements VisitableRelationship {
 
     @Builder
     public RootRelationship(String description) {
@@ -20,7 +20,7 @@ public class RootRelationship extends DescribableEntity implements Visitable {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.relation;
 
+import org.opentosca.toscana.model.visitor.RelationshipVisitor;
 import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
@@ -22,7 +23,7 @@ public class RoutesTo extends RootRelationship {
     }
 
     @Override
-    public void accept(Visitor v) {
+    public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
@@ -1,7 +1,6 @@
 package org.opentosca.toscana.model.relation;
 
 import org.opentosca.toscana.model.visitor.RelationshipVisitor;
-import org.opentosca.toscana.model.visitor.Visitor;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
@@ -16,51 +16,65 @@ import org.opentosca.toscana.model.capability.PublicEndpointCapability;
 import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.capability.StorageCapability;
 
-public interface CapabilityVisitor extends Visitor{
-    
-    default void visit(AdminEndpointCapability capability){
+public interface CapabilityVisitor extends Visitor {
+
+    default void visit(AdminEndpointCapability capability) {
         throw new UnsupportedTypeException(AdminEndpointCapability.class);
     }
-    default void visit(AttachmentCapability capability){
+
+    default void visit(AttachmentCapability capability) {
         throw new UnsupportedTypeException(AttachmentCapability.class);
     }
-    default void visit(BindableCapability capability){
+
+    default void visit(BindableCapability capability) {
         throw new UnsupportedTypeException(BindableCapability.class);
     }
-    default void visit(Capability capability){
+
+    default void visit(Capability capability) {
         throw new UnsupportedTypeException(Capability.class);
     }
-    default void visit(ComputeCapability capability){
+
+    default void visit(ComputeCapability capability) {
         throw new UnsupportedTypeException(ComputeCapability.class);
     }
-    default void visit(ContainerCapability capability){
+
+    default void visit(ContainerCapability capability) {
         throw new UnsupportedTypeException(ContainerCapability.class);
     }
-    default void visit(DatabaseEndpointCapability capability){
+
+    default void visit(DatabaseEndpointCapability capability) {
         throw new UnsupportedTypeException(DatabaseEndpointCapability.class);
     }
-    default void visit(DockerContainerCapability capability){
+
+    default void visit(DockerContainerCapability capability) {
         throw new UnsupportedTypeException(DockerContainerCapability.class);
     }
-    default void visit(EndpointCapability capability){
+
+    default void visit(EndpointCapability capability) {
         throw new UnsupportedTypeException(EndpointCapability.class);
     }
-    default void visit(NetworkCapability capability){
+
+    default void visit(NetworkCapability capability) {
         throw new UnsupportedTypeException(NetworkCapability.class);
     }
-    default void visit(NodeCapability capability){
+
+    default void visit(NodeCapability capability) {
         throw new UnsupportedTypeException(NodeCapability.class);
     }
-    default void visit(OsCapability capability){
+
+    default void visit(OsCapability capability) {
         throw new UnsupportedTypeException(OsCapability.class);
     }
-    default void visit(PublicEndpointCapability capability){
+
+    default void visit(PublicEndpointCapability capability) {
         throw new UnsupportedTypeException(PublicEndpointCapability.class);
     }
-    default void visit(ScalableCapability capability){
+
+    default void visit(ScalableCapability capability) {
         throw new UnsupportedTypeException(ScalableCapability.class);
     }
-    default void visit(StorageCapability capability){
+
+    default void visit(StorageCapability capability) {
         throw new UnsupportedTypeException(StorageCapability.class);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
@@ -16,7 +16,7 @@ import org.opentosca.toscana.model.capability.PublicEndpointCapability;
 import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.capability.StorageCapability;
 
-public interface CapabilityVisitor extends Visitor {
+public interface CapabilityVisitor {
 
     default void visit(AdminEndpointCapability capability) {
         throw new UnsupportedTypeException(AdminEndpointCapability.class);

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/NodeVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/NodeVisitor.java
@@ -19,7 +19,7 @@ import org.opentosca.toscana.model.node.WebApplication;
 import org.opentosca.toscana.model.node.WebServer;
 import org.opentosca.toscana.model.node.WordPress;
 
-public interface NodeVisitor extends Visitor {
+public interface NodeVisitor {
 
     default void visit(Apache node) {
         throw new UnsupportedTypeException(Apache.class);

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/RelationshipVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/RelationshipVisitor.java
@@ -7,7 +7,7 @@ import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.relation.RoutesTo;
 
-public interface RelationshipVisitor extends Visitor {
+public interface RelationshipVisitor {
 
     default void visit(RootRelationship relation) {
         throw new UnsupportedTypeException(RootRelationship.class);

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/Visitable.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/Visitable.java
@@ -1,6 +1,0 @@
-package org.opentosca.toscana.model.visitor;
-
-public interface Visitable {
-    
-    public void accept(Visitor v);
-}

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableCapability.java
@@ -1,6 +1,6 @@
 package org.opentosca.toscana.model.visitor;
 
 public interface VisitableCapability {
-    
-    public void accept(CapabilityVisitor v);   
+
+    public void accept(CapabilityVisitor v);
 }

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableCapability.java
@@ -1,0 +1,6 @@
+package org.opentosca.toscana.model.visitor;
+
+public interface VisitableCapability {
+    
+    public void accept(CapabilityVisitor v);   
+}

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableNode.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableNode.java
@@ -1,0 +1,6 @@
+package org.opentosca.toscana.model.visitor;
+
+public interface VisitableNode {
+    
+    public void accept(NodeVisitor v);   
+}

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableNode.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableNode.java
@@ -1,6 +1,6 @@
 package org.opentosca.toscana.model.visitor;
 
 public interface VisitableNode {
-    
-    public void accept(NodeVisitor v);   
+
+    public void accept(NodeVisitor v);
 }

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableRelationship.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableRelationship.java
@@ -1,6 +1,6 @@
 package org.opentosca.toscana.model.visitor;
 
 public interface VisitableRelationship {
-    
-    public void accept(RelationshipVisitor v);   
+
+    public void accept(RelationshipVisitor v);
 }

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableRelationship.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/VisitableRelationship.java
@@ -1,0 +1,6 @@
+package org.opentosca.toscana.model.visitor;
+
+public interface VisitableRelationship {
+    
+    public void accept(RelationshipVisitor v);   
+}

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/Visitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/Visitor.java
@@ -1,8 +1,0 @@
-package org.opentosca.toscana.model.visitor;
-
-public interface Visitor {
-
-    default void visit(Visitable v) {
-        throw new UnsupportedTypeException(Object.class);
-    }
-}


### PR DESCRIPTION
@jmuell pointed out that the visitor pattern doesn't work like he expected.
Investigation showed that the implementation was buggy.
This pr should fix the issue.

## Stacktrace (before fix)
This happened when calling a node's accept method with an implemenation of NodeVisitor:
```
org.opentosca.toscana.model.visitor.UnsupportedTypeException: Type 'java.lang.Object' is not supported
    at org.opentosca.toscana.model.visitor.Visitor.visit(Visitor.java:6)
    at org.opentosca.toscana.model.node.WebApplication.accept(WebApplication.java:79)
    at org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryLifecycle.transform(CloudFoundryLifecycle.java:88)
    at org.opentosca.toscana.plugins.lifecycle.ExecutionPhase.execute(ExecutionPhase.java:31)
    at org.opentosca.toscana.plugins.lifecycle.LifecycleAwarePlugin.transform(LifecycleAwarePlugin.java:80)
    at org.opentosca.toscana.core.transformation.execution.ExecutionTask.transform(ExecutionTask.java:78)
    at org.opentosca.toscana.core.transformation.execution.ExecutionTask.run(ExecutionTask.java:52)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748) `
```