### PR TITLE
Make RootNode abstract

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
@@ -78,9 +78,6 @@ public class ContainerApplication extends RootNode {
             .storage(storage);
     }
 
-    public static class ContainerApplicationBuilder extends RootNodeBuilder {
-    }
-
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
@@ -65,9 +65,6 @@ public class LoadBalancer extends RootNode {
         return Optional.ofNullable(algorithm);
     }
 
-    public static class LoadBalancerBuilder extends RootNodeBuilder {
-    }
-
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
@@ -11,17 +11,15 @@ import org.opentosca.toscana.model.capability.Requirement;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.DependsOn;
-import org.opentosca.toscana.model.visitor.NodeVisitor;
 import org.opentosca.toscana.model.visitor.VisitableNode;
 
-import lombok.Builder;
 import lombok.Data;
 
 /**
  The base node. Every other node will derive from this class.
  */
 @Data
-public class RootNode extends DescribableEntity implements VisitableNode {
+public abstract class RootNode extends DescribableEntity implements VisitableNode {
 
     protected final Set<Requirement> requirements = new HashSet<>();
     protected final Set<Capability> capabilities = new HashSet<>();
@@ -46,8 +44,6 @@ public class RootNode extends DescribableEntity implements VisitableNode {
 
     private final StandardLifecycle standardLifecycle;
 
-
-    @Builder
     protected RootNode(String nodeName,
                        StandardLifecycle standardLifecycle,
                        String description) {
@@ -59,14 +55,5 @@ public class RootNode extends DescribableEntity implements VisitableNode {
         this.standardLifecycle = (standardLifecycle == null) ? StandardLifecycle.builder().build() : standardLifecycle;
         capabilities.add(feature);
         requirements.addAll(dependencies);
-    }
-
-    public static RootNodeBuilder builder(String nodeName) {
-        return new RootNodeBuilder().nodeName(nodeName);
-    }
-
-    @Override
-    public void accept(NodeVisitor v) {
-        v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -71,9 +71,6 @@ public class WebApplication extends RootNode {
         return Optional.ofNullable(contextRoot);
     }
 
-    public static class WebApplicationBuilder extends RootNodeBuilder {
-    }
-
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/NodeVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/NodeVisitor.java
@@ -13,7 +13,6 @@ import org.opentosca.toscana.model.node.MysqlDatabase;
 import org.opentosca.toscana.model.node.MysqlDbms;
 import org.opentosca.toscana.model.node.Nodejs;
 import org.opentosca.toscana.model.node.ObjectStorage;
-import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.node.SoftwareComponent;
 import org.opentosca.toscana.model.node.WebApplication;
 import org.opentosca.toscana.model.node.WebServer;
@@ -71,10 +70,6 @@ public interface NodeVisitor {
 
     default void visit(ObjectStorage node) {
         throw new UnsupportedTypeException(ObjectStorage.class);
-    }
-
-    default void visit(RootNode node) {
-        throw new UnsupportedTypeException(RootNode.class);
     }
 
     default void visit(SoftwareComponent node) {


### PR DESCRIPTION
According to the TOSCA spec, a RootNode itself is abstract. Also, the winery parser does not allow node templates of type Root. 