### PR TITLE
Fix abstract Root Types

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
@@ -25,9 +25,6 @@ public class AttachmentCapability extends Capability {
         super(validSourceTypes, occurence, description);
     }
 
-    public static class AttachmentCapabilityBuilder extends CapabilityBuilder {
-    }
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
@@ -6,10 +6,8 @@ import java.util.Set;
 import org.opentosca.toscana.model.DescribableEntity;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
-import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 import org.opentosca.toscana.model.visitor.VisitableCapability;
 
-import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.Singular;
@@ -19,7 +17,7 @@ import lombok.Singular;
  (TOSCA Simple Profile in YAML Version 1.1, p. 82)
  */
 @Data
-public class Capability extends DescribableEntity implements VisitableCapability {
+public abstract class Capability extends DescribableEntity implements VisitableCapability {
 
     /**
      Set of Node Class Types that are valid sources of any relationship established to this capability.
@@ -36,17 +34,11 @@ public class Capability extends DescribableEntity implements VisitableCapability
     @NonNull
     private final Range occurence;
 
-    @Builder
     protected Capability(@Singular Set<Class<? extends RootNode>> validSourceTypes,
                          Range occurence,
                          String description) {
         super(description);
         this.validSourceTypes = Objects.requireNonNull(validSourceTypes);
         this.occurence = (occurence != null) ? occurence : Range.AT_LEAST_ONCE;
-    }
-
-    @Override
-    public void accept(CapabilityVisitor v) {
-        v.visit(this);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
@@ -126,9 +126,6 @@ public class ComputeCapability extends Capability {
         return Optional.ofNullable(memSizeInMB);
     }
 
-    public static class ComputeCapabilityBuilder extends CapabilityBuilder {
-    }
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
@@ -90,7 +90,7 @@ public class DockerContainerCapability extends ContainerCapability {
         this.hostId = hostId;
         this.volumeId = volumeId;
     }
-    
+
     /**
      @return {@link #hostId}
      */

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
@@ -40,9 +40,6 @@ public class NetworkCapability extends Capability {
         return Optional.ofNullable(name);
     }
 
-    public static class NetworkCapabilityBuilder extends CapabilityBuilder {
-    }
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
@@ -24,9 +24,6 @@ public class NodeCapability extends Capability {
         super(validSourceTypes, occurence, description);
     }
 
-    public static class NodeCapabilityBuilder extends CapabilityBuilder {
-    }
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
@@ -113,9 +113,6 @@ public class OsCapability extends Capability {
         return Optional.ofNullable(version);
     }
 
-    public static class OsCapabilityBuilder extends CapabilityBuilder {
-    }
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
@@ -40,9 +40,6 @@ public class StorageCapability extends Capability {
         return Optional.ofNullable(name);
     }
 
-    public static class StorageCapabilityBuilder extends CapabilityBuilder {
-    }
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/AttachesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/AttachesTo.java
@@ -59,9 +59,6 @@ public class AttachesTo extends RootRelationship {
         return new AttachesToBuilder().mountPoint(mountPoint);
     }
 
-    public static class AttachesToBuilder extends RootRelationshipBuilder {
-    }
-
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
@@ -35,9 +35,6 @@ public class ConnectsTo extends RootRelationship {
         return Optional.ofNullable(credential);
     }
 
-    public static class ConnectsToBuilder extends RootRelationshipBuilder {
-    }
-
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
@@ -16,9 +16,6 @@ public class DependsOn extends RootRelationship {
         super(description);
     }
 
-    public static class DependsOnBuilder extends RootRelationshipBuilder {
-    }
-
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
@@ -17,9 +17,6 @@ public class HostedOn extends RootRelationship {
         super(description);
     }
 
-    public static class HostedOnBuilder extends RootRelationshipBuilder {
-    }
-
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
@@ -1,10 +1,8 @@
 package org.opentosca.toscana.model.relation;
 
 import org.opentosca.toscana.model.DescribableEntity;
-import org.opentosca.toscana.model.visitor.RelationshipVisitor;
 import org.opentosca.toscana.model.visitor.VisitableRelationship;
 
-import lombok.Builder;
 import lombok.Data;
 
 /**
@@ -12,15 +10,10 @@ import lombok.Data;
  (TOSCA Simple Profile in YAML Version 1.1, p. 159)
  */
 @Data
-public class RootRelationship extends DescribableEntity implements VisitableRelationship {
+public abstract class RootRelationship extends DescribableEntity implements VisitableRelationship {
 
-    @Builder
-    public RootRelationship(String description) {
+    protected RootRelationship(String description) {
         super(description);
     }
 
-    @Override
-    public void accept(RelationshipVisitor v) {
-        v.visit(this);
-    }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
@@ -18,9 +18,6 @@ public class RoutesTo extends RootRelationship {
         super(description);
     }
 
-    public static class RoutesToBuilder extends RootRelationshipBuilder {
-    }
-
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
@@ -3,7 +3,6 @@ package org.opentosca.toscana.model.visitor;
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
 import org.opentosca.toscana.model.capability.AttachmentCapability;
 import org.opentosca.toscana.model.capability.BindableCapability;
-import org.opentosca.toscana.model.capability.Capability;
 import org.opentosca.toscana.model.capability.ComputeCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
@@ -26,10 +25,6 @@ public interface CapabilityVisitor {
     }
 
     default void visit(BindableCapability capability) {
-        // noop
-    }
-
-    default void visit(Capability capability) {
         // noop
     }
 
@@ -76,5 +71,5 @@ public interface CapabilityVisitor {
     default void visit(StorageCapability capability) {
         // noop
     }
-    
+
 }

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/RelationshipVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/RelationshipVisitor.java
@@ -4,14 +4,9 @@ import org.opentosca.toscana.model.relation.AttachesTo;
 import org.opentosca.toscana.model.relation.ConnectsTo;
 import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.relation.HostedOn;
-import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.relation.RoutesTo;
 
 public interface RelationshipVisitor {
-
-    default void visit(RootRelationship relation) {
-        // noop
-    }
 
     default void visit(AttachesTo relation) {
         // noop

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/StrictCapabilityVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/StrictCapabilityVisitor.java
@@ -3,7 +3,6 @@ package org.opentosca.toscana.model.visitor;
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
 import org.opentosca.toscana.model.capability.AttachmentCapability;
 import org.opentosca.toscana.model.capability.BindableCapability;
-import org.opentosca.toscana.model.capability.Capability;
 import org.opentosca.toscana.model.capability.ComputeCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
@@ -20,7 +19,7 @@ import org.opentosca.toscana.model.capability.StorageCapability;
  Unimplemented methods throw an {@link UnsupportedTypeException} when invoked.
  */
 public interface StrictCapabilityVisitor extends CapabilityVisitor {
-    
+
     @Override
     default void visit(AdminEndpointCapability capability) {
         throw new UnsupportedTypeException(AdminEndpointCapability.class);
@@ -34,11 +33,6 @@ public interface StrictCapabilityVisitor extends CapabilityVisitor {
     @Override
     default void visit(BindableCapability capability) {
         throw new UnsupportedTypeException(BindableCapability.class);
-    }
-
-    @Override
-    default void visit(Capability capability) {
-        throw new UnsupportedTypeException(Capability.class);
     }
 
     @Override

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/StrictRelationshipVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/StrictRelationshipVisitor.java
@@ -4,18 +4,12 @@ import org.opentosca.toscana.model.relation.AttachesTo;
 import org.opentosca.toscana.model.relation.ConnectsTo;
 import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.relation.HostedOn;
-import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.relation.RoutesTo;
 
 /**
  Unimplemented methods throw an {@link UnsupportedTypeException} when invoked.
  */
 public interface StrictRelationshipVisitor extends RelationshipVisitor {
-
-    @Override
-    default void visit(RootRelationship relation) {
-        throw new UnsupportedTypeException(RootRelationship.class);
-    }
 
     @Override
     default void visit(AttachesTo relation) {


### PR DESCRIPTION
After making `RootNode` abstract in a previous PR, this PR also makes `Capability` and `RootRelationship` abstract.
The TOSCA spec is not too clear about whether root capabilities and root relationships are allowed to get instantiated - but I'm quite sure it is not allowed. The spec states somewhere that in general, the modeler must use the most specialized type.

In addition to spec conformance, it makes plugin development easier (as less `visit()` methods need to get implemented).