### PR TITLE
Refactor effective model

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/model/DescribableEntity.java
+++ b/server/src/main/java/org/opentosca/toscana/model/DescribableEntity.java
@@ -26,22 +26,8 @@ public class DescribableEntity implements Serializable {
     }
 
     public static class DescribableEntityBuilder implements Serializable {
-        private String description;
 
         public DescribableEntityBuilder() {
-        }
-
-        public DescribableEntityBuilder description(String description) {
-            this.description = description;
-            return this;
-        }
-
-        public DescribableEntity build() {
-            return new DescribableEntity(description);
-        }
-
-        public String toString() {
-            return "DescribableEntity.DescribableEntityBuilder(description=" + this.description + ")";
         }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/DescribableEntity.java
+++ b/server/src/main/java/org/opentosca/toscana/model/DescribableEntity.java
@@ -1,23 +1,47 @@
 package org.opentosca.toscana.model;
 
+import java.io.Serializable;
+
+import lombok.Builder;
 import lombok.Data;
 
 /**
  Inherit from this if there's need to describe the entity.
  */
 @Data
-public class DescribableEntity {
+public class DescribableEntity implements Serializable {
 
     /**
      The optional description of this.
      */
     private final String description;
 
-    protected DescribableEntity() {
+    public DescribableEntity() {
         description = "";
     }
 
-    protected DescribableEntity(String description) {
+    @Builder
+    public DescribableEntity(String description) {
         this.description = description == null ? "" : description;
+    }
+
+    public static class DescribableEntityBuilder implements Serializable {
+        private String description;
+
+        public DescribableEntityBuilder() {
+        }
+
+        public DescribableEntityBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public DescribableEntity build() {
+            return new DescribableEntity(description);
+        }
+
+        public String toString() {
+            return "DescribableEntity.DescribableEntityBuilder(description=" + this.description + ")";
+        }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/AdminEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AdminEndpointCapability.java
@@ -32,27 +32,42 @@ public class AdminEndpointCapability extends EndpointCapability {
                                       String portName,
                                       String networkName,
                                       Initiator initiator,
-                                      @Singular Set<PortSpec> ports,
+                                      @Singular Set<PortSpec> supportedPorts,
                                       String ipAddress,
-                                      @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                      Set<Class<? extends RootNode>> validSourceTypes,
                                       Range occurence,
                                       String description) {
         super(protocol, port, true, urlPath, portName, networkName, initiator,
-            ports, ipAddress, validSourceTypes, occurence, description);
+            supportedPorts, ipAddress, validSourceTypes, occurence, description);
     }
 
     /**
      @param ipAddress {@link #ipAddress}
+     @param port      {@link #port}
      */
-    public static AdminEndpointCapabilityBuilder builder(String ipAddress) {
-        return new AdminEndpointCapabilityBuilder().ipAddress(ipAddress);
+    public static AdminEndpointCapabilityBuilder builder(String ipAddress,
+                                                         Port port) {
+        return new AdminEndpointCapabilityBuilder()
+            .ipAddress(ipAddress)
+            .port(port);
     }
 
-    public static class AdminEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
+    /**
+     @param ipAddress     {@link #ipAddress}
+     @param supportedPort {@link #supportedPorts}
+     */
+    public static AdminEndpointCapabilityBuilder builder(String ipAddress,
+                                                         PortSpec supportedPort) {
+        return new AdminEndpointCapabilityBuilder()
+            .ipAddress(ipAddress)
+            .supportedPort(supportedPort);
     }
 
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+
+    public static class AdminEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  Defines an attachment capability of a (logical) infrastructure device node (e.g., {@link BlockStorage} node).
@@ -24,13 +23,13 @@ public class AttachmentCapability extends Capability {
         super(validSourceTypes, occurence, description);
     }
 
+    public static AttachmentCapability getFallback(AttachmentCapability c) {
+        return (c == null) ? AttachmentCapability.builder().build() : c;
+    }
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
-    }
-
-    public static AttachmentCapability getFallback(AttachmentCapability c) {
-        return (c == null) ? AttachmentCapability.builder().build() : c;
     }
 
     public static class AttachmentCapabilityBuilder extends CapabilityBuilder {

--- a/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/AttachmentCapability.java
@@ -18,7 +18,7 @@ import lombok.Singular;
 public class AttachmentCapability extends Capability {
 
     @Builder
-    protected AttachmentCapability(@Singular Set<Class<? extends RootNode>> validSourceTypes,
+    protected AttachmentCapability(Set<Class<? extends RootNode>> validSourceTypes,
                                    Range occurence,
                                    String description) {
         super(validSourceTypes, occurence, description);
@@ -27,5 +27,12 @@ public class AttachmentCapability extends Capability {
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+
+    public static AttachmentCapability getFallback(AttachmentCapability c) {
+        return (c == null) ? AttachmentCapability.builder().build() : c;
+    }
+
+    public static class AttachmentCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
@@ -18,17 +18,18 @@ import lombok.Singular;
 public class BindableCapability extends NodeCapability {
 
     @Builder
-    protected BindableCapability(@Singular Set<Class<? extends RootNode>> validSourceTypes,
+    protected BindableCapability(Set<Class<? extends RootNode>> validSourceTypes,
                                  Range occurence,
                                  String description) {
         super(validSourceTypes, occurence, description);
     }
 
-    public static class BindableCapabilityBuilder extends NodeCapabilityBuilder {
-    }
 
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+    
+    public static class BindableCapabilityBuilder extends NodeCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/BindableCapability.java
@@ -8,7 +8,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  A node that has the BindableCapability indicates that it can be bound to a logical network association via a network port.
@@ -24,12 +23,11 @@ public class BindableCapability extends NodeCapability {
         super(validSourceTypes, occurence, description);
     }
 
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
-    
+
     public static class BindableCapabilityBuilder extends NodeCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
@@ -1,6 +1,6 @@
 package org.opentosca.toscana.model.capability;
 
-import java.util.Objects;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.opentosca.toscana.model.DescribableEntity;
@@ -8,9 +8,9 @@ import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.visitor.VisitableCapability;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
-import lombok.Singular;
 
 /**
  Defines a set of data that can be associated with a {@link RootNode} to describe its capability or feature.
@@ -34,11 +34,28 @@ public abstract class Capability extends DescribableEntity implements VisitableC
     @NonNull
     private final Range occurence;
 
-    protected Capability(@Singular Set<Class<? extends RootNode>> validSourceTypes,
+    @Builder
+    protected Capability(Set<Class<? extends RootNode>> validSourceTypes,
                          Range occurence,
                          String description) {
         super(description);
-        this.validSourceTypes = Objects.requireNonNull(validSourceTypes);
+        this.validSourceTypes = (validSourceTypes == null) ? new HashSet<>() : validSourceTypes;
         this.occurence = (occurence != null) ? occurence : Range.AT_LEAST_ONCE;
+    }
+
+    public static class CapabilityBuilder extends DescribableEntityBuilder {
+
+        private Set<Class<? extends RootNode>> validSourceTypes = new HashSet<>();
+        
+        @Override
+        public Capability build() {
+            // should never be called (RootNode is abstract)
+            throw new UnsupportedOperationException();
+        }
+
+        public CapabilityBuilder validSourceType(Class<? extends RootNode> sourceType) {
+            validSourceTypes.add(sourceType);
+            return this;
+        }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
@@ -46,7 +46,7 @@ public abstract class Capability extends DescribableEntity implements VisitableC
     public static class CapabilityBuilder extends DescribableEntityBuilder {
 
         private Set<Class<? extends RootNode>> validSourceTypes = new HashSet<>();
-        
+
         @Override
         public Capability build() {
             // should never be called (RootNode is abstract)

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
@@ -27,7 +27,7 @@ public class ComputeCapability extends Capability {
      Optional name (or identifier) of a specific compute resource for hosting.
      (TOSCA Simple Profile in YAML Version 1.1, p. 150)
      */
-    private final String name;
+    private final String resourceName;
 
     /**
      Optional number of (actual or virtual) CPUs associated with the {@link Compute} node.
@@ -59,12 +59,12 @@ public class ComputeCapability extends Capability {
     private final Integer memSizeInMB;
 
     @Builder
-    protected ComputeCapability(String name,
+    protected ComputeCapability(String resourceName,
                                 Integer numCpus,
                                 Double cpuFrequencyInGhz,
                                 Integer diskSizeInMB,
                                 Integer memSizeInMB,
-                                @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                Set<Class<? extends RootNode>> validSourceTypes,
                                 Range occurence,
                                 String description) {
         super(validSourceTypes, occurence, description);
@@ -84,7 +84,7 @@ public class ComputeCapability extends Capability {
             throw new IllegalArgumentException(String.format(
                 "memSize min value is 0, but was %d", memSizeInMB));
         }
-        this.name = name;
+        this.resourceName = resourceName;
         this.numCpus = numCpus;
         this.cpuFrequencyInGhz = cpuFrequencyInGhz;
         this.diskSizeInMB = diskSizeInMB;
@@ -92,10 +92,10 @@ public class ComputeCapability extends Capability {
     }
 
     /**
-     @return {@link #name}
+     @return {@link #resourceName}
      */
-    public Optional<String> getName() {
-        return Optional.ofNullable(name);
+    public Optional<String> getResourceName() {
+        return Optional.ofNullable(resourceName);
     }
 
     /**
@@ -129,5 +129,8 @@ public class ComputeCapability extends Capability {
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+    
+    public static class ComputeCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ComputeCapability.java
@@ -13,7 +13,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  Indicates that the node can provide hosting on a named compute resource.
@@ -130,7 +129,7 @@ public class ComputeCapability extends Capability {
     public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
-    
+
     public static class ComputeCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
@@ -17,22 +17,26 @@ import lombok.Singular;
 public class ContainerCapability extends ComputeCapability {
 
     @Builder
-    protected ContainerCapability(String name,
+    protected ContainerCapability(String resourceName,
                                   Integer numCpus,
                                   Double cpuFrequencyInGhz,
                                   Integer diskSizeInMB,
                                   Integer memSizeInMB,
-                                  @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                  Set<Class<? extends RootNode>> validSourceTypes,
                                   Range occurence,
                                   String description) {
-        super(name, numCpus, cpuFrequencyInGhz, diskSizeInMB, memSizeInMB, validSourceTypes, occurence, description);
+        super(resourceName, numCpus, cpuFrequencyInGhz, diskSizeInMB, memSizeInMB, validSourceTypes, occurence, description);
     }
 
-    public static class ContainerCapabilityBuilder extends ComputeCapabilityBuilder {
+    public static ContainerCapability getFallback(ContainerCapability c) {
+        return (c == null) ? ContainerCapability.builder().build() : c;
     }
-
+    
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+
+    public static class ContainerCapabilityBuilder extends ComputeCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ContainerCapability.java
@@ -8,7 +8,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  The ContainerCapability indicates that the node can act as a container (or a host) for one or more other declared Node Types.
@@ -31,7 +30,7 @@ public class ContainerCapability extends ComputeCapability {
     public static ContainerCapability getFallback(ContainerCapability c) {
         return (c == null) ? ContainerCapability.builder().build() : c;
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
@@ -38,13 +38,12 @@ public class DatabaseEndpointCapability extends EndpointCapability {
             supportedPorts, ipAddress, validSourceTypes, occurence, description);
     }
 
-
     /**
      @param ipAddress {@link #ipAddress}
      @param port      {@link #port}
      */
     public static DatabaseEndpointCapabilityBuilder builder(String ipAddress,
-                                                          Port port) {
+                                                            Port port) {
         return new DatabaseEndpointCapabilityBuilder()
             .ipAddress(ipAddress)
             .port(port);
@@ -55,17 +54,17 @@ public class DatabaseEndpointCapability extends EndpointCapability {
      @param supportedPort {@link #supportedPorts}
      */
     public static DatabaseEndpointCapabilityBuilder builder(String ipAddress,
-                                                          PortSpec supportedPort) {
+                                                            PortSpec supportedPort) {
         return new DatabaseEndpointCapabilityBuilder()
             .ipAddress(ipAddress)
             .supportedPort(supportedPort);
     }
-    
+
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
-    
+
     public static class DatabaseEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DatabaseEndpointCapability.java
@@ -29,26 +29,43 @@ public class DatabaseEndpointCapability extends EndpointCapability {
                                          String portName,
                                          String networkName,
                                          Initiator initiator,
-                                         @Singular Set<PortSpec> ports,
+                                         @Singular Set<PortSpec> supportedPorts,
                                          String ipAddress,
-                                         @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                         Set<Class<? extends RootNode>> validSourceTypes,
                                          Range occurence,
                                          String description) {
-        super(protocol, port, secure, urlPath, portName, networkName, initiator, ports, ipAddress, validSourceTypes, occurence, description);
+        super(protocol, port, secure, urlPath, portName, networkName, initiator,
+            supportedPorts, ipAddress, validSourceTypes, occurence, description);
     }
+
 
     /**
      @param ipAddress {@link #ipAddress}
+     @param port      {@link #port}
      */
-    public static DatabaseEndpointCapabilityBuilder builder(String ipAddress) {
-        return new DatabaseEndpointCapabilityBuilder().ipAddress(ipAddress);
+    public static DatabaseEndpointCapabilityBuilder builder(String ipAddress,
+                                                          Port port) {
+        return new DatabaseEndpointCapabilityBuilder()
+            .ipAddress(ipAddress)
+            .port(port);
     }
 
-    public static class DatabaseEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
+    /**
+     @param ipAddress     {@link #ipAddress}
+     @param supportedPort {@link #supportedPorts}
+     */
+    public static DatabaseEndpointCapabilityBuilder builder(String ipAddress,
+                                                          PortSpec supportedPort) {
+        return new DatabaseEndpointCapabilityBuilder()
+            .ipAddress(ipAddress)
+            .supportedPort(supportedPort);
     }
-
+    
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+    
+    public static class DatabaseEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
@@ -73,15 +73,15 @@ public class DockerContainerCapability extends ContainerCapability {
                                         @Singular Set<String> volumes,
                                         String hostId,
                                         String volumeId,
-                                        String name,
+                                        String resourceName,
                                         Integer numCpus,
                                         Double cpuFrequencyInGhz,
                                         Integer diskSizeInMB,
                                         Integer memSizeInMB,
-                                        @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                        Set<Class<? extends RootNode>> validSourceTypes,
                                         Range occurence,
                                         String description) {
-        super(name, numCpus, cpuFrequencyInGhz, diskSizeInMB, memSizeInMB, validSourceTypes, occurence, description);
+        super(resourceName, numCpus, cpuFrequencyInGhz, diskSizeInMB, memSizeInMB, validSourceTypes, occurence, description);
         this.versions = Objects.requireNonNull(versions);
         this.publishAll = publishAll;
         this.publishPorts = Objects.requireNonNull(publishPorts);
@@ -89,6 +89,11 @@ public class DockerContainerCapability extends ContainerCapability {
         this.volumes = Objects.requireNonNull(volumes);
         this.hostId = hostId;
         this.volumeId = volumeId;
+    }
+    
+    public static DockerContainerCapability getFallback(DockerContainerCapability c){
+        return (c == null) ? DockerContainerCapability.builder().build() : c;
+        
     }
 
     /**
@@ -105,11 +110,11 @@ public class DockerContainerCapability extends ContainerCapability {
         return Optional.ofNullable(volumeId);
     }
 
-    public static class DockerContainerCapabilityBuilder extends ContainerCapabilityBuilder {
-    }
-
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+   
+    public static class DockerContainerCapabilityBuilder extends ContainerCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/DockerContainerCapability.java
@@ -90,10 +90,9 @@ public class DockerContainerCapability extends ContainerCapability {
         this.hostId = hostId;
         this.volumeId = volumeId;
     }
-    
-    public static DockerContainerCapability getFallback(DockerContainerCapability c){
+
+    public static DockerContainerCapability getFallback(DockerContainerCapability c) {
         return (c == null) ? DockerContainerCapability.builder().build() : c;
-        
     }
 
     /**
@@ -114,7 +113,7 @@ public class DockerContainerCapability extends ContainerCapability {
     public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
-   
+
     public static class DockerContainerCapabilityBuilder extends ContainerCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
@@ -161,15 +161,15 @@ public class EndpointCapability extends Capability {
         return Optional.ofNullable(initiator);
     }
 
+    @Override
+    public void accept(CapabilityVisitor v) {
+        v.visit(this);
+    }
+
     public enum Initiator {
         SOURCE,
         TARGET,
         PEER
-    }
-
-    @Override
-    public void accept(CapabilityVisitor v) {
-        v.visit(this);
     }
 
     public static class EndpointCapabilityBuilder extends CapabilityBuilder {

--- a/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/EndpointCapability.java
@@ -85,7 +85,7 @@ public class EndpointCapability extends Capability {
                                  Initiator initiator,
                                  @Singular Set<PortSpec> supportedPorts,
                                  String ipAddress,
-                                 @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                 Set<Class<? extends RootNode>> validSourceTypes,
                                  Range occurence,
                                  String description) {
         super(validSourceTypes, occurence, description);
@@ -170,5 +170,8 @@ public class EndpointCapability extends Capability {
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+
+    public static class EndpointCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  The NetworkCapability indicates that the node can provide addressability for the resource within a network.
@@ -44,7 +43,7 @@ public class NetworkCapability extends Capability {
     public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
-    
+
     public static class NetworkCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NetworkCapability.java
@@ -26,7 +26,7 @@ public class NetworkCapability extends Capability {
 
     @Builder
     protected NetworkCapability(String name,
-                                @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                Set<Class<? extends RootNode>> validSourceTypes,
                                 Range occurence,
                                 String description) {
         super(validSourceTypes, occurence, description);
@@ -43,5 +43,8 @@ public class NetworkCapability extends Capability {
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+    
+    public static class NetworkCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
@@ -18,7 +18,7 @@ import lombok.Singular;
 public class NodeCapability extends Capability {
 
     @Builder
-    protected NodeCapability(@Singular Set<Class<? extends RootNode>> validSourceTypes,
+    protected NodeCapability(Set<Class<? extends RootNode>> validSourceTypes,
                              Range occurence,
                              String description) {
         super(validSourceTypes, occurence, description);
@@ -27,5 +27,8 @@ public class NodeCapability extends Capability {
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+    
+    public static class NodeCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/NodeCapability.java
@@ -8,7 +8,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  The NodeCapability indicates the base capabilities of a TOSCA Node Type.
@@ -28,7 +27,7 @@ public class NodeCapability extends Capability {
     public void accept(CapabilityVisitor v) {
         v.visit(this);
     }
-    
+
     public static class NodeCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
@@ -44,7 +44,7 @@ public class OsCapability extends Capability {
                            Type type,
                            Distribution distribution,
                            String version,
-                           @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                           Set<Class<? extends RootNode>> validSourceTypes,
                            Range occurence,
                            String description) {
         super(validSourceTypes, occurence, description);
@@ -113,5 +113,8 @@ public class OsCapability extends Capability {
         BUSYBOX,
         OPEN_SUSE,
         // might grow
+    }
+    
+    public static class OsCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/OsCapability.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  The default TOSCA type to express an Operating System capability for a node.
@@ -114,7 +113,7 @@ public class OsCapability extends Capability {
         OPEN_SUSE,
         // might grow
     }
-    
+
     public static class OsCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
@@ -59,13 +59,13 @@ public class PublicEndpointCapability extends EndpointCapability {
                                        String portName,
                                        String networkName,
                                        Initiator initiator,
-                                       @Singular Set<PortSpec> ports,
+                                       @Singular Set<PortSpec> supportedPorts,
                                        String ipAddress,
-                                       @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                       Set<Class<? extends RootNode>> validSourceTypes,
                                        Range occurence,
                                        String description) {
         super(protocol, port, secure, urlPath, portName, (networkName != null ? networkName : "PUBLIC"),
-            initiator, ports, ipAddress, validSourceTypes, occurence, description);
+            initiator, supportedPorts, ipAddress, validSourceTypes, occurence, description);
         if (networkName.equalsIgnoreCase("private")) {
             throw new IllegalArgumentException("Constraint violation: network name must not equal 'private'");
         }
@@ -80,19 +80,33 @@ public class PublicEndpointCapability extends EndpointCapability {
         return Optional.ofNullable(dnsName);
     }
 
-
     /**
      @param ipAddress {@link #ipAddress}
+     @param port      {@link #port}
      */
-    public static PublicEndpointCapabilityBuilder builder(String ipAddress) {
-        return new PublicEndpointCapabilityBuilder().ipAddress(ipAddress);
+    public static PublicEndpointCapabilityBuilder builder(String ipAddress,
+                                                          Port port) {
+        return new PublicEndpointCapabilityBuilder()
+            .ipAddress(ipAddress)
+            .port(port);
     }
 
-    public static class PublicEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
+    /**
+     @param ipAddress     {@link #ipAddress}
+     @param supportedPort {@link #supportedPorts}
+     */
+    public static PublicEndpointCapabilityBuilder builder(String ipAddress,
+                                                          PortSpec supportedPort) {
+        return new PublicEndpointCapabilityBuilder()
+            .ipAddress(ipAddress)
+            .supportedPort(supportedPort);
     }
 
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+
+    public static class PublicEndpointCapabilityBuilder extends EndpointCapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/PublicEndpointCapability.java
@@ -74,13 +74,6 @@ public class PublicEndpointCapability extends EndpointCapability {
     }
 
     /**
-     @return {@link #dnsName}
-     */
-    public Optional<String> getDnsName() {
-        return Optional.ofNullable(dnsName);
-    }
-
-    /**
      @param ipAddress {@link #ipAddress}
      @param port      {@link #port}
      */
@@ -100,6 +93,13 @@ public class PublicEndpointCapability extends EndpointCapability {
         return new PublicEndpointCapabilityBuilder()
             .ipAddress(ipAddress)
             .supportedPort(supportedPort);
+    }
+
+    /**
+     @return {@link #dnsName}
+     */
+    public Optional<String> getDnsName() {
+        return Optional.ofNullable(dnsName);
     }
 
     @Override

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 import static java.lang.String.format;
 

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
@@ -1,6 +1,5 @@
 package org.opentosca.toscana.model.capability;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -25,6 +24,8 @@ public class ScalableCapability extends Capability {
      Indicates the minimum and maximum number of instances that should be created
      for the associated TOSCA Node Template by a TOSCA orchestrator.
      (TOSCA Simple Profile in YAML Version 1.1, p. 157)
+     <p>
+     Defaults to {@link Range#EXACTLY_ONCE}.
      */
     private final Range scaleRange;
 
@@ -38,26 +39,18 @@ public class ScalableCapability extends Capability {
     @Builder
     protected ScalableCapability(Range scaleRange,
                                  Integer defaultInstances,
-                                 @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                 Set<Class<? extends RootNode>> validSourceTypes,
                                  Range occurence,
                                  String description) {
         super(validSourceTypes, occurence, description);
+        this.scaleRange = (scaleRange == null) ? Range.EXACTLY_ONCE : scaleRange;
+        this.defaultInstances = defaultInstances;
         if (defaultInstances != null && !scaleRange.inRange(defaultInstances)) {
             throw new IllegalArgumentException(format(
                 "Constraint violation: range.min (%d) <= defaultInstances (%d) <= range.max (%d)",
                 scaleRange.min, defaultInstances, scaleRange.max));
         }
-        this.scaleRange = Objects.requireNonNull(scaleRange);
-        this.defaultInstances = defaultInstances;
     }
-
-    /**
-     @param scaleRange {@link #scaleRange}
-     */
-    public static ScalableCapabilityBuilder builder(Range scaleRange) {
-        return new ScalableCapabilityBuilder().scaleRange(scaleRange);
-    }
-
 
     /**
      @return {@link #defaultInstances}
@@ -68,7 +61,9 @@ public class ScalableCapability extends Capability {
 
     @Override
     public void accept(CapabilityVisitor v) {
-
         v.visit(this);
+    }
+
+    public static class ScalableCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
@@ -26,7 +26,7 @@ public class StorageCapability extends Capability {
 
     @Builder
     protected StorageCapability(String name,
-                                @Singular Set<Class<? extends RootNode>> validSourceTypes,
+                                Set<Class<? extends RootNode>> validSourceTypes,
                                 Range occurence,
                                 String description) {
         super(validSourceTypes, occurence, description);
@@ -43,5 +43,12 @@ public class StorageCapability extends Capability {
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
+    }
+
+    public static StorageCapability getFallback(StorageCapability c) {
+        return (c == null) ? StorageCapability.builder().build() : c;
+    }
+
+    public static class StorageCapabilityBuilder extends CapabilityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/StorageCapability.java
@@ -9,7 +9,6 @@ import org.opentosca.toscana.model.visitor.CapabilityVisitor;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 /**
  The StorageCapability indicates that the node can provide a named storage location with specified size range.
@@ -33,6 +32,10 @@ public class StorageCapability extends Capability {
         this.name = name;
     }
 
+    public static StorageCapability getFallback(StorageCapability c) {
+        return (c == null) ? StorageCapability.builder().build() : c;
+    }
+
     /**
      @return {@link #name}
      */
@@ -43,10 +46,6 @@ public class StorageCapability extends Capability {
     @Override
     public void accept(CapabilityVisitor v) {
         v.visit(this);
-    }
-
-    public static StorageCapability getFallback(StorageCapability c) {
-        return (c == null) ? StorageCapability.builder().build() : c;
     }
 
     public static class StorageCapabilityBuilder extends CapabilityBuilder {

--- a/server/src/main/java/org/opentosca/toscana/model/datatype/PortSpec.java
+++ b/server/src/main/java/org/opentosca/toscana/model/datatype/PortSpec.java
@@ -47,7 +47,6 @@ public class PortSpec {
      */
     public final Range targetRange;
 
-
     @Builder
     private PortSpec(PortProtocol protocol,
                      Port source,

--- a/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
@@ -52,7 +52,7 @@ public class Apache extends WebServer {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-   
+
     public static class ApacheBuilder extends WebServerBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Apache.java
@@ -3,11 +3,9 @@ package org.opentosca.toscana.model.node;
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
@@ -29,35 +27,32 @@ public class Apache extends WebServer {
                      String nodeName,
                      StandardLifecycle lifecycle,
                      String description) {
-        super(componentVersion, adminCredential, host, containerHost,
+        super(componentVersion, adminCredential, HostRequirement.getFallback(host), containerHost,
             databaseEndpoint, adminEndpoint, nodeName, lifecycle, description);
     }
 
     /**
      @param nodeName      {@link #nodeName}
-     @param host          {@link #host}
      @param containerHost {@link #containerHost}
      @param dataEndpoint  {@link #dataEndpoint}
      @param adminEndpoint {@link #adminEndpoint}
      */
     public static ApacheBuilder builder(String nodeName,
-                                        HostRequirement host,
                                         ContainerCapability containerHost,
                                         EndpointCapability dataEndpoint,
                                         AdminEndpointCapability adminEndpoint) {
         return (ApacheBuilder) new ApacheBuilder()
             .nodeName(nodeName)
-            .host(host)
             .containerHost(containerHost)
             .dataEndpoint(dataEndpoint)
             .adminEndpoint(adminEndpoint);
     }
 
-    public static class ApacheBuilder extends WebServerBuilder {
-    }
-
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+   
+    public static class ApacheBuilder extends WebServerBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
@@ -79,7 +79,6 @@ public class BlockStorage extends RootNode {
         capabilities.add(this.attachment);
     }
 
-
     /**
      @param attachment {@link #attachment}
      @param lifecycle  {@link #standardLifecycle}
@@ -108,7 +107,6 @@ public class BlockStorage extends RootNode {
             .attachment(attachment);
     }
 
-
     /**
      @return the optional size of this block storage (in MB)
      */
@@ -134,7 +132,7 @@ public class BlockStorage extends RootNode {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-    
+
     public static class BlockStorageBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/BlockStorage.java
@@ -76,7 +76,7 @@ public class BlockStorage extends RootNode {
         this.snapshotId = snapshotId;
         this.attachment = Objects.requireNonNull(attachment);
 
-        capabilities.add(attachment);
+        capabilities.add(this.attachment);
     }
 
 
@@ -133,5 +133,8 @@ public class BlockStorage extends RootNode {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+    
+    public static class BlockStorageBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
@@ -6,37 +6,37 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
-import org.opentosca.toscana.model.capability.AttachmentCapability;
 import org.opentosca.toscana.model.capability.BindableCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.OsCapability;
-import org.opentosca.toscana.model.requirement.BlockStorageRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.datatype.NetworkInfo;
 import org.opentosca.toscana.model.datatype.PortInfo;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.AttachesTo;
+import org.opentosca.toscana.model.requirement.BlockStorageRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
 import lombok.Data;
 
 /**
- Represents one or more real or virtual processors of software applications or services along with other essential local resources.
+ Represents one or more real or virtual processors of software applications or services along with other essential local
+ resources.
  Collectively, the resources the compute node represents can logically be viewed as a (real or virtual) “server”.
  (TOSCA Simple Profile in YAML Version 1.1, p. 169)
  */
 @Data
 public class Compute extends RootNode {
     /**
-     The optional primary private IP address assigned by the cloud provider that applications may use to access the Compute node.
+     The optional primary private IP address assigned by the cloud provider that applications may use to access the
+     Compute node.
      (TOSCA Simple Profile in YAML Version 1.1, p. 169)
      */
     private final String privateAddress;
 
     /**
-     The optional primary public IP address assigned by the cloud provider that applications may use to access the Compute node.
+     The optional primary public IP address assigned by the cloud provider that applications may use to access the
+     Compute node.
      (TOSCA Simple Profile in YAML Version 1.1, p. 169)
      */
     private final String publicAddress;
@@ -80,40 +80,34 @@ public class Compute extends RootNode {
         super(nodeName, standardLifecycle, description);
         this.privateAddress = privateAddress;
         this.publicAddress = publicAddress;
-        this.host = Objects.requireNonNull(host);
         this.os = Objects.requireNonNull(os);
         this.adminEndpoint = Objects.requireNonNull(adminEndpoint);
-        this.scalable = Objects.requireNonNull(scalable);
-        this.binding = Objects.requireNonNull(binding);
+        this.host = (host == null) ? ContainerCapability.builder().build() : host;
+        this.scalable = (scalable == null) ? ScalableCapability.builder().build() : scalable;
+        this.binding = (binding == null) ? BindableCapability.builder().build() : binding;
         this.localStorage = Objects.requireNonNull(localStorage);
 
-        capabilities.add(host);
-        capabilities.add(os);
-        capabilities.add(adminEndpoint);
-        capabilities.add(scalable);
-        capabilities.add(binding);
-        requirements.add(localStorage);
+        capabilities.add(this.host);
+        capabilities.add(this.os);
+        capabilities.add(this.adminEndpoint);
+        capabilities.add(this.scalable);
+        capabilities.add(this.binding);
+        requirements.add(this.localStorage);
     }
 
     /**
      @param nodeName      {@link #nodeName}
      @param adminEndpoint {@link #adminEndpoint}
-     @param scalable      {@link #scalable}
-     @param binding       {@link #binding}
      @param localStorage  {@link #localStorage}
      */
     public static ComputeBuilder builder(String nodeName,
                                          OsCapability os,
                                          AdminEndpointCapability adminEndpoint,
-                                         ScalableCapability scalable,
-                                         BindableCapability binding,
                                          BlockStorageRequirement localStorage) {
         return new ComputeBuilder()
             .os(os)
             .nodeName(nodeName)
             .adminEndpoint(adminEndpoint)
-            .scalable(scalable)
-            .binding(binding)
             .localStorage(localStorage);
     }
 
@@ -134,6 +128,9 @@ public class Compute extends RootNode {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class ComputeBuilder extends RootNodeBuilder {
     }
 }
 

--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
@@ -2,15 +2,9 @@ package org.opentosca.toscana.model.node;
 
 import java.util.Objects;
 
-import org.opentosca.toscana.model.capability.ContainerCapability;
-import org.opentosca.toscana.model.capability.EndpointCapability;
+import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.requirement.ContainerHostRequirement;
 import org.opentosca.toscana.model.requirement.EndpointRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
-import org.opentosca.toscana.model.capability.StorageCapability;
-import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
-import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.requirement.StorageRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -38,13 +32,13 @@ public class ContainerApplication extends RootNode {
                                    StandardLifecycle standardLifecycle,
                                    String description) {
         super(nodeName, standardLifecycle, description);
-        this.host = Objects.requireNonNull(host);
-        this.storage = Objects.requireNonNull(storage);
+        this.storage = StorageRequirement.getFallback(storage);
+        this.host = ContainerHostRequirement.getFallback(host);
         this.network = Objects.requireNonNull(network);
 
         requirements.add(host);
-        requirements.add(storage);
-        requirements.add(network);
+        requirements.add(this.storage);
+        requirements.add(this.network);
     }
 
     /**
@@ -57,32 +51,29 @@ public class ContainerApplication extends RootNode {
                                    String description) {
         super(nodeName, standardLifecycle, description);
         this.host = null; // this is a hack. field shall not be used because its shadowed by the subclass
-        this.storage = Objects.requireNonNull(storage);
+        this.storage = StorageRequirement.getFallback(storage);
         this.network = Objects.requireNonNull(network);
 
-        requirements.add(storage);
-        requirements.add(network);
+        requirements.add(this.storage);
+        requirements.add(this.network);
     }
 
     /**
      @param nodeName {@link #nodeName}
-     @param host     {@link #host}
      @param network  {@link #network}
-     @param network  {@link #storage}
      */
     public static ContainerApplicationBuilder builder(String nodeName,
-                                                      ContainerHostRequirement host,
-                                                      EndpointRequirement network,
-                                                      StorageRequirement storage) {
+                                                      EndpointRequirement network) {
         return new ContainerApplicationBuilder()
             .nodeName(nodeName)
-            .host(host)
-            .network(network)
-            .storage(storage);
+            .network(network);
     }
 
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class ContainerApplicationBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerRuntime.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerRuntime.java
@@ -1,7 +1,5 @@
 package org.opentosca.toscana.model.node;
 
-import java.util.Objects;
-
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.datatype.Credential;
@@ -42,7 +40,7 @@ public class ContainerRuntime extends SoftwareComponent {
     }
 
     /**
-     @param nodeName      {@link #nodeName}
+     @param nodeName {@link #nodeName}
      */
     public static ContainerRuntimeBuilder builder(String nodeName) {
         return new ContainerRuntimeBuilder()

--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerRuntime.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerRuntime.java
@@ -3,12 +3,10 @@ package org.opentosca.toscana.model.node;
 import java.util.Objects;
 
 import org.opentosca.toscana.model.capability.ContainerCapability;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
@@ -36,8 +34,8 @@ public class ContainerRuntime extends SoftwareComponent {
                              StandardLifecycle standardLifecycle,
                              String description) {
         super(componentVersion, adminCredential, host, nodeName, standardLifecycle, description);
-        this.containerHost = Objects.requireNonNull(containerHost);
-        this.scalable = Objects.requireNonNull(scalable);
+        this.containerHost = (containerHost == null) ? ContainerCapability.builder().build() : containerHost;
+        this.scalable = (scalable == null) ? ScalableCapability.builder().build() : scalable;
 
         capabilities.add(containerHost);
         capabilities.add(scalable);
@@ -45,23 +43,17 @@ public class ContainerRuntime extends SoftwareComponent {
 
     /**
      @param nodeName      {@link #nodeName}
-     @param host          {@link #host}
-     @param containerHost {@link #containerHost}
-     @param scalable      {@link #scalable}
      */
-    public static ContainerRuntimeBuilder builder(String nodeName,
-                                                  HostRequirement host,
-                                                  ContainerCapability containerHost,
-                                                  ScalableCapability scalable) {
+    public static ContainerRuntimeBuilder builder(String nodeName) {
         return new ContainerRuntimeBuilder()
-            .nodeName(nodeName)
-            .scalable(scalable)
-            .host(host)
-            .containerHost(containerHost);
+            .nodeName(nodeName);
     }
 
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class ContainerRuntimeBuilder extends SoftwareComponentBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Database.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Database.java
@@ -130,7 +130,7 @@ public class Database extends RootNode {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-    
+
     public static class DatabaseBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Database.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Database.java
@@ -85,7 +85,7 @@ public class Database extends RootNode {
         this.host = null;
         this.databaseEndpoint = Objects.requireNonNull(databaseEndpoint);
 
-        capabilities.add(databaseEndpoint);
+        capabilities.add(this.databaseEndpoint);
     }
 
     /**
@@ -129,5 +129,8 @@ public class Database extends RootNode {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+    
+    public static class DatabaseBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Dbms.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Dbms.java
@@ -4,11 +4,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.opentosca.toscana.model.capability.ContainerCapability;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
@@ -50,7 +48,7 @@ public class Dbms extends SoftwareComponent {
         this.port = port;
         this.rootPassword = rootPassword;
 
-        capabilities.add(containerHost);
+        capabilities.add(this.containerHost);
     }
 
     /**
@@ -84,5 +82,8 @@ public class Dbms extends SoftwareComponent {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class DbmsBuilder extends SoftwareComponentBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
@@ -1,20 +1,11 @@
 package org.opentosca.toscana.model.node;
 
-import java.util.Objects;
-
-import org.opentosca.toscana.model.capability.DockerContainerCapability;
-import org.opentosca.toscana.model.capability.EndpointCapability;
+import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.requirement.DockerHostRequirement;
 import org.opentosca.toscana.model.requirement.EndpointRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
-import org.opentosca.toscana.model.capability.StorageCapability;
-import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
-import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.requirement.StorageRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
-import com.spotify.docker.client.DockerHost;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -35,30 +26,26 @@ public class DockerApplication extends ContainerApplication {
                               StandardLifecycle standardLifecycle,
                               String description) {
         super(storage, network, nodeName, standardLifecycle, description);
-        this.host = Objects.requireNonNull(host);
-
-        requirements.add(host);
+        this.host = DockerHostRequirement.getFallback(host);
+        requirements.add(this.host);
     }
 
     /**
      @param nodeName {@link #nodeName}
-     @param host     {@link #host}
      @param network  {@link #network}
-     @param storage  {@link #storage}
      */
-    public static DockerApplicationBuilder builder(DockerHostRequirement host,
-                                                   String nodeName,
-                                                   EndpointRequirement network,
-                                                   StorageRequirement storage) {
+    public static DockerApplicationBuilder builder(String nodeName,
+                                                   EndpointRequirement network) {
         return new DockerApplicationBuilder()
             .nodeName(nodeName)
-            .host(host)
-            .network(network)
-            .storage(storage);
+            .network(network);
     }
 
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class DockerApplicationBuilder extends ContainerApplicationBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
@@ -68,7 +68,7 @@ public class LoadBalancer extends RootNode {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-    
+
     public static class LoadBalancerBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
@@ -42,8 +42,8 @@ public class LoadBalancer extends RootNode {
         this.application = applicationBuilder.occurrence(Range.ANY).build();
         this.algorithm = algorithm;
 
-        capabilities.add(client);
-        requirements.add(application);
+        capabilities.add(this.client);
+        requirements.add(this.application);
     }
 
     /**
@@ -67,5 +67,8 @@ public class LoadBalancer extends RootNode {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+    
+    public static class LoadBalancerBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
@@ -27,7 +27,7 @@ public class MysqlDatabase extends Database {
                          StandardLifecycle standardLifecycle,
                          String description) {
         super(databaseName, port, user, password, databaseEndpoint, nodeName, standardLifecycle, description);
-        
+
         this.host = (host == null) ? MysqlDbmsRequirement.builder().build() : host;
 
         requirements.add(this.host);

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
@@ -1,11 +1,8 @@
 package org.opentosca.toscana.model.node;
 
-import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
-import org.opentosca.toscana.model.requirement.MysqlDbmsRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.MysqlDbmsRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.AccessLevel;
@@ -30,24 +27,22 @@ public class MysqlDatabase extends Database {
                          StandardLifecycle standardLifecycle,
                          String description) {
         super(databaseName, port, user, password, databaseEndpoint, nodeName, standardLifecycle, description);
-        this.host = host;
+        
+        this.host = (host == null) ? MysqlDbmsRequirement.builder().build() : host;
 
-        requirements.add(host);
+        requirements.add(this.host);
     }
 
     /**
      @param nodeName         {@link #nodeName}
      @param databaseName     {@link #databaseEndpoint}
-     @param host             {@link #host}
      @param databaseEndpoint {@link #databaseEndpoint}
      */
     public static MysqlDatabaseBuilder builder(String nodeName,
                                                String databaseName,
-                                               DatabaseEndpointCapability databaseEndpoint,
-                                               MysqlDbmsRequirement host) {
+                                               DatabaseEndpointCapability databaseEndpoint) {
         return (MysqlDatabaseBuilder) new MysqlDatabaseBuilder()
             .nodeName(nodeName)
-            .host(host)
             .databaseName(databaseName)
             .databaseEndpoint(databaseEndpoint);
     }
@@ -55,5 +50,8 @@ public class MysqlDatabase extends Database {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class MysqlDatabaseBuilder extends DatabaseBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
@@ -31,8 +31,8 @@ public class MysqlDbms extends Dbms {
     }
 
     /**
-     @param nodeName      {@link #nodeName}
-     @param rootPassword  {@link #rootPassword}
+     @param nodeName     {@link #nodeName}
+     @param rootPassword {@link #rootPassword}
      */
     public static MysqlDbmsBuilder builder(String nodeName,
                                            String rootPassword) {

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDbms.java
@@ -1,12 +1,9 @@
 package org.opentosca.toscana.model.node;
 
 import org.opentosca.toscana.model.capability.ContainerCapability;
-import org.opentosca.toscana.model.capability.ContainerCapability.ContainerCapabilityBuilder;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
@@ -21,7 +18,7 @@ public class MysqlDbms extends Dbms {
 
     @Builder
     private MysqlDbms(HostRequirement host,
-                      ContainerCapabilityBuilder containerHostBuilder,
+                      ContainerCapability containerHost,
                       String rootPassword,
                       Integer port,
                       String componentVersion,
@@ -29,40 +26,36 @@ public class MysqlDbms extends Dbms {
                       String nodeName,
                       StandardLifecycle lifecycle,
                       String description) {
-        super(host, makeValidContainerHost(containerHostBuilder), rootPassword, fallbackPort(port),
+        super(HostRequirement.getFallback(host), makeValidContainerHost(containerHost), rootPassword, fallbackPort(port),
             componentVersion, adminCredential, nodeName, lifecycle, description);
     }
 
     /**
-     @param nodeName             {@link #nodeName}
-     @param rootPassword         {@link #rootPassword}
-     @param host                 {@link #host}
-     @param containerHostBuilder {@link #containerHost}
+     @param nodeName      {@link #nodeName}
+     @param rootPassword  {@link #rootPassword}
      */
     public static MysqlDbmsBuilder builder(String nodeName,
-                                           String rootPassword,
-                                           HostRequirement host,
-                                           ContainerCapabilityBuilder containerHostBuilder) {
-        return (MysqlDbmsBuilder) new MysqlDbmsBuilder()
+                                           String rootPassword) {
+        return new MysqlDbmsBuilder()
             .nodeName(nodeName)
-            .rootPassword(rootPassword)
-            .host(host)
-            .containerHostBuilder(containerHostBuilder);
+            .rootPassword(rootPassword);
     }
 
-    private static ContainerCapability makeValidContainerHost(ContainerCapabilityBuilder hostBuilder) {
-        return hostBuilder.clearValidSourceTypes().validSourceType(MysqlDatabase.class).build();
+    private static ContainerCapability makeValidContainerHost(ContainerCapability host) {
+        host = ContainerCapability.getFallback(host);
+        host.getValidSourceTypes().add((MysqlDatabase.class));
+        return host;
     }
 
     private static Integer fallbackPort(Integer port) {
         return (port == null) ? 3306 : port;
     }
 
-    public static class MysqlDbmsBuilder extends DbmsBuilder {
-    }
-
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class MysqlDbmsBuilder extends DbmsBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
@@ -5,11 +5,9 @@ import java.util.Optional;
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
@@ -68,7 +66,7 @@ public class Nodejs extends WebServer {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-    
+
     public static class NodejsBuilder extends WebServerBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Nodejs.java
@@ -64,11 +64,11 @@ public class Nodejs extends WebServer {
         return Optional.ofNullable(githubUrl);
     }
 
-    public static class NodejsBuilder extends WebServerBuilder {
-    }
-
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+    
+    public static class NodejsBuilder extends WebServerBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
@@ -72,7 +72,6 @@ public class ObjectStorage extends RootNode {
             .storageEndpoint(storageEndpoint);
     }
 
-
     /**
      @return {@link #sizeInGB}
      */
@@ -91,7 +90,7 @@ public class ObjectStorage extends RootNode {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-    
+
     public static class ObjectStorageBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
@@ -55,7 +55,7 @@ public class ObjectStorage extends RootNode {
         this.maxSizeInGB = maxSizeInGB;
         this.storageEndpoint = Objects.requireNonNull(storageEndpoint);
 
-        capabilities.add(storageEndpoint);
+        capabilities.add(this.storageEndpoint);
     }
 
     /**
@@ -90,5 +90,8 @@ public class ObjectStorage extends RootNode {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+    
+    public static class ObjectStorageBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
@@ -35,14 +35,12 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
      Every node has the capability of a node.
      */
     private final NodeCapability feature = NodeCapability.builder().occurence(Range.EXACTLY_ONCE).build();
-
+    private final StandardLifecycle standardLifecycle;
     /**
      Dependencies are generic requirements that can be used to express timing dependencies between nodes.
      (TOSCA Simple Profile in YAML Version 1.1, p. 23)
      */
     private Set<Dependency> dependencies = new HashSet<>();
-
-    private final StandardLifecycle standardLifecycle;
 
     @Builder
     protected RootNode(String nodeName,
@@ -67,10 +65,37 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
 
     public static class RootNodeBuilder extends DescribableEntityBuilder {
 
+        private String nodeName;
+        private StandardLifecycle standardLifecycle;
+        private String description;
+
+        RootNodeBuilder() {
+        }
+
         @Override
         public RootNode build() {
             // should never be called (RootNode is abstract)
             throw new UnsupportedOperationException();
+        }
+
+        public RootNodeBuilder nodeName(String nodeName) {
+            this.nodeName = nodeName;
+            return this;
+        }
+
+        public RootNodeBuilder standardLifecycle(StandardLifecycle standardLifecycle) {
+            this.standardLifecycle = standardLifecycle;
+            return this;
+        }
+
+        @Override
+        public RootNodeBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public String toString() {
+            return "RootNode.RootNodeBuilder(nodeName=" + this.nodeName + ", standardLifecycle=" + this.standardLifecycle + ", description=" + this.description + ")";
         }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
@@ -7,13 +7,13 @@ import java.util.Set;
 import org.opentosca.toscana.model.DescribableEntity;
 import org.opentosca.toscana.model.capability.Capability;
 import org.opentosca.toscana.model.capability.NodeCapability;
-import org.opentosca.toscana.model.requirement.Dependency;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.DependsOn;
+import org.opentosca.toscana.model.requirement.Dependency;
+import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.visitor.VisitableNode;
 
+import lombok.Builder;
 import lombok.Data;
 
 /**
@@ -36,7 +36,6 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
      */
     private final NodeCapability feature = NodeCapability.builder().occurence(Range.EXACTLY_ONCE).build();
 
-
     /**
      Dependencies are generic requirements that can be used to express timing dependencies between nodes.
      (TOSCA Simple Profile in YAML Version 1.1, p. 23)
@@ -45,6 +44,7 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
 
     private final StandardLifecycle standardLifecycle;
 
+    @Builder
     protected RootNode(String nodeName,
                        StandardLifecycle standardLifecycle,
                        String description) {
@@ -54,7 +54,23 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
             throw new IllegalArgumentException("name must not be empty");
         }
         this.standardLifecycle = (standardLifecycle == null) ? StandardLifecycle.builder().build() : standardLifecycle;
-        capabilities.add(feature);
-        requirements.addAll(dependencies);
+        capabilities.add(this.feature);
+        requirements.addAll(this.dependencies);
+    }
+
+    /**
+     @param nodeName {@link #nodeName}
+     */
+    public static RootNodeBuilder builder(String nodeName) {
+        return new RootNodeBuilder().nodeName(nodeName);
+    }
+
+    public static class RootNodeBuilder extends DescribableEntityBuilder {
+
+        @Override
+        public RootNode build() {
+            // should never be called (RootNode is abstract)
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
@@ -68,6 +68,57 @@ public class SoftwareComponent extends RootNode {
     }
 
     public static class SoftwareComponentBuilder extends RootNodeBuilder {
+        private String componentVersion;
+        private Credential adminCredential;
+        private HostRequirement host;
+        private String nodeName;
+        private StandardLifecycle standardLifecycle;
+        private String description;
+
+        SoftwareComponentBuilder() {
+        }
+
+        public SoftwareComponentBuilder componentVersion(String componentVersion) {
+            this.componentVersion = componentVersion;
+            return this;
+        }
+
+        public SoftwareComponentBuilder adminCredential(Credential adminCredential) {
+            this.adminCredential = adminCredential;
+            return this;
+        }
+
+        public SoftwareComponentBuilder host(HostRequirement host) {
+            this.host = host;
+            return this;
+        }
+
+        @Override
+        public SoftwareComponentBuilder nodeName(String nodeName) {
+            this.nodeName = nodeName;
+            return this;
+        }
+
+        @Override
+        public SoftwareComponentBuilder standardLifecycle(StandardLifecycle standardLifecycle) {
+            this.standardLifecycle = standardLifecycle;
+            return this;
+        }
+
+        @Override
+        public SoftwareComponentBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public SoftwareComponent build() {
+            return new SoftwareComponent(componentVersion, adminCredential, host, nodeName, standardLifecycle, description);
+        }
+
+        public String toString() {
+            return "SoftwareComponent.SoftwareComponentBuilder(componentVersion=" + this.componentVersion + ", adminCredential=" + this.adminCredential + ", host=" + this.host + ", nodeName=" + this.nodeName + ", standardLifecycle=" + this.standardLifecycle + ", description=" + this.description + ")";
+        }
     }
 }
 

--- a/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
@@ -1,14 +1,10 @@
 package org.opentosca.toscana.model.node;
 
-import java.util.Objects;
 import java.util.Optional;
 
-import org.opentosca.toscana.model.capability.ContainerCapability;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
 import lombok.Builder;
@@ -45,20 +41,17 @@ public class SoftwareComponent extends RootNode {
         super(nodeName, standardLifecycle, description);
         this.componentVersion = componentVersion;
         this.adminCredential = adminCredential;
-        this.host = Objects.requireNonNull(host);
+        this.host = (host == null) ? HostRequirement.builder().build() : host;
 
-        requirements.add(host);
+        requirements.add(this.host);
     }
 
     /**
      @param nodeName {@link #nodeName}
-     @param host     {@link #host}
      */
-    public static SoftwareComponentBuilder builder(String nodeName,
-                                                   HostRequirement host) {
+    public static SoftwareComponentBuilder builder(String nodeName) {
         return new SoftwareComponentBuilder()
-            .nodeName(nodeName)
-            .host(host);
+            .nodeName(nodeName);
     }
 
     public Optional<String> getComponentVersion() {
@@ -73,4 +66,8 @@ public class SoftwareComponent extends RootNode {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
+
+    public static class SoftwareComponentBuilder extends RootNodeBuilder {
+    }
 }
+

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -3,10 +3,8 @@ package org.opentosca.toscana.model.node;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.WebServerRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -68,7 +66,7 @@ public class WebApplication extends RootNode {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-    
+
     public static class WebApplicationBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -41,15 +41,9 @@ public class WebApplication extends RootNode {
         super(nodeName, standardLifecycle, description);
         this.contextRoot = contextRoot;
         this.appEndpoint = Objects.requireNonNull(endpoint);
-        if (host != null) {
-            this.host = host;
-        } else {
-            ContainerCapability containerCapability = ContainerCapability.builder().build();
-            this.host = WebServerRequirement.builder(
-                containerCapability, HostedOn.builder().build()).build();
-        }
+        this.host = (host == null) ? WebServerRequirement.builder().build() : host;
 
-        capabilities.add(appEndpoint);
+        capabilities.add(this.appEndpoint);
         requirements.add(this.host);
     }
 
@@ -73,5 +67,8 @@ public class WebApplication extends RootNode {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+    
+    public static class WebApplicationBuilder extends RootNodeBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
@@ -5,15 +5,10 @@ import java.util.Objects;
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.Requirement;
 import org.opentosca.toscana.model.datatype.Credential;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
-
-import lombok.Builder;
-import lombok.Data;
 
 /**
  Represents an abstract software component or service that is capable of hosting and providing management operations
@@ -23,7 +18,6 @@ import lombok.Data;
  administration, as well as a regular endpoint ({@link #dataEndpoint}) for serving data.
  (TOSCA Simple Profile in YAML Version 1.1, p.171)
  */
-@Data
 public class WebServer extends SoftwareComponent {
 
     private final EndpointCapability dataEndpoint;
@@ -32,7 +26,6 @@ public class WebServer extends SoftwareComponent {
 
     private final ContainerCapability containerHost;
 
-    @Builder
     protected WebServer(String componentVersion,
                         Credential adminCredential,
                         HostRequirement host,
@@ -76,7 +69,134 @@ public class WebServer extends SoftwareComponent {
     public void accept(NodeVisitor v) {
         v.visit(this);
     }
-    
+
+    public EndpointCapability getDataEndpoint() {
+        return this.dataEndpoint;
+    }
+
+    public AdminEndpointCapability getAdminEndpoint() {
+        return this.adminEndpoint;
+    }
+
+    public ContainerCapability getContainerHost() {
+        return this.containerHost;
+    }
+
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (!(o instanceof WebServer)) return false;
+        final WebServer other = (WebServer) o;
+        if (!other.canEqual((Object) this)) return false;
+        if (!super.equals(o)) return false;
+        final Object this$dataEndpoint = this.getDataEndpoint();
+        final Object other$dataEndpoint = other.getDataEndpoint();
+        if (this$dataEndpoint == null ? other$dataEndpoint != null : !this$dataEndpoint.equals(other$dataEndpoint))
+            return false;
+        final Object this$adminEndpoint = this.getAdminEndpoint();
+        final Object other$adminEndpoint = other.getAdminEndpoint();
+        if (this$adminEndpoint == null ? other$adminEndpoint != null : !this$adminEndpoint.equals(other$adminEndpoint))
+            return false;
+        final Object this$containerHost = this.getContainerHost();
+        final Object other$containerHost = other.getContainerHost();
+        if (this$containerHost == null ? other$containerHost != null : !this$containerHost.equals(other$containerHost))
+            return false;
+        return true;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + super.hashCode();
+        final Object $dataEndpoint = this.getDataEndpoint();
+        result = result * PRIME + ($dataEndpoint == null ? 43 : $dataEndpoint.hashCode());
+        final Object $adminEndpoint = this.getAdminEndpoint();
+        result = result * PRIME + ($adminEndpoint == null ? 43 : $adminEndpoint.hashCode());
+        final Object $containerHost = this.getContainerHost();
+        result = result * PRIME + ($containerHost == null ? 43 : $containerHost.hashCode());
+        return result;
+    }
+
+    @Override
+    protected boolean canEqual(Object other) {
+        return other instanceof WebServer;
+    }
+
+    public String toString() {
+        return "WebServer(dataEndpoint=" + this.getDataEndpoint() + ", adminEndpoint=" + this.getAdminEndpoint() + ", containerHost=" + this.getContainerHost() + ")";
+    }
+
     public static class WebServerBuilder extends SoftwareComponentBuilder {
+        private String componentVersion;
+        private Credential adminCredential;
+        private HostRequirement host;
+        private ContainerCapability containerHost;
+        private EndpointCapability dataEndpoint;
+        private AdminEndpointCapability adminEndpoint;
+        private String nodeName;
+        private StandardLifecycle standardLifecycle;
+        private String description;
+
+        WebServerBuilder() {
+        }
+
+        @Override
+        public WebServerBuilder componentVersion(String componentVersion) {
+            this.componentVersion = componentVersion;
+            return this;
+        }
+
+        @Override
+        public WebServerBuilder adminCredential(Credential adminCredential) {
+            this.adminCredential = adminCredential;
+            return this;
+        }
+
+        @Override
+        public WebServerBuilder host(HostRequirement host) {
+            this.host = host;
+            return this;
+        }
+
+        public WebServerBuilder containerHost(ContainerCapability containerHost) {
+            this.containerHost = containerHost;
+            return this;
+        }
+
+        public WebServerBuilder dataEndpoint(EndpointCapability dataEndpoint) {
+            this.dataEndpoint = dataEndpoint;
+            return this;
+        }
+
+        public WebServerBuilder adminEndpoint(AdminEndpointCapability adminEndpoint) {
+            this.adminEndpoint = adminEndpoint;
+            return this;
+        }
+
+        @Override
+        public WebServerBuilder nodeName(String nodeName) {
+            this.nodeName = nodeName;
+            return this;
+        }
+
+        @Override
+        public WebServerBuilder standardLifecycle(StandardLifecycle standardLifecycle) {
+            this.standardLifecycle = standardLifecycle;
+            return this;
+        }
+
+        @Override
+        public WebServerBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public WebServer build() {
+            return new WebServer(componentVersion, adminCredential, host, containerHost, dataEndpoint, adminEndpoint, nodeName, standardLifecycle, description);
+        }
+
+        public String toString() {
+            return "WebServer.WebServerBuilder(componentVersion=" + this.componentVersion + ", adminCredential=" + this.adminCredential + ", host=" + this.host + ", containerHost=" + this.containerHost + ", dataEndpoint=" + this.dataEndpoint + ", adminEndpoint=" + this.adminEndpoint + ", nodeName=" + this.nodeName + ", standardLifecycle=" + this.standardLifecycle + ", description=" + this.description + ")";
+        }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebServer.java
@@ -47,9 +47,9 @@ public class WebServer extends SoftwareComponent {
         this.dataEndpoint = Objects.requireNonNull(dataEndpoint);
         this.adminEndpoint = Objects.requireNonNull(adminEndpoint);
 
-        capabilities.add(containerHost);
-        capabilities.add(dataEndpoint);
-        capabilities.add(adminEndpoint);
+        capabilities.add(this.containerHost);
+        capabilities.add(this.dataEndpoint);
+        capabilities.add(this.adminEndpoint);
     }
 
     /**
@@ -75,5 +75,8 @@ public class WebServer extends SoftwareComponent {
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+    
+    public static class WebServerBuilder extends SoftwareComponentBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
@@ -75,11 +75,11 @@ public class WordPress extends WebApplication {
         return new WordPressBuilder();
     }
 
-    public static class WordPressBuilder extends WebApplicationBuilder {
-    }
-
     @Override
     public void accept(NodeVisitor v) {
         v.visit(this);
+    }
+
+    public static class WordPressBuilder extends WebApplicationBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/operation/Operation.java
+++ b/server/src/main/java/org/opentosca/toscana/model/operation/Operation.java
@@ -31,7 +31,7 @@ public class Operation extends DescribableEntity {
      several dependent or secondary implementation artifact names which
      are referenced by the primary implementation artifact
      (e.g., a library the script installs or a secondary script).
-     Might be empty.
+     Might be empty
      */
     private final Set<String> dependencies;
 
@@ -46,7 +46,6 @@ public class Operation extends DescribableEntity {
      Might be empty.
      */
     private final Set<OperationVariable> outputs;
-
 
     @Builder
     protected Operation(String implementationArtifact,
@@ -77,4 +76,6 @@ public class Operation extends DescribableEntity {
         return Optional.ofNullable(artifact);
     }
 
+    public static class OperationBuilder extends DescribableEntityBuilder {
+    }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
@@ -39,4 +39,7 @@ public class ConnectsTo extends RootRelationship {
     public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
+    
+    public static class ConnectsToBuilder extends DescribableEntityBuilder {
+    }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/ConnectsTo.java
@@ -39,7 +39,7 @@ public class ConnectsTo extends RootRelationship {
     public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
-    
+
     public static class ConnectsToBuilder extends DescribableEntityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
@@ -11,22 +11,22 @@ import lombok.Data;
 @Data
 public class DependsOn extends RootRelationship {
 
-    public DependsOn(){
+    public DependsOn() {
         super(null);
     }
-    
+
     @Builder
     protected DependsOn(String description) {
         super(description);
     }
 
+    public static RootRelationship getFallback(RootRelationship rel) {
+        return (rel == null) ? builder().build() : rel;
+    }
+
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);
-    }
-
-    public static RootRelationship getFallback(RootRelationship rel) {
-        return (rel == null) ? builder().build() : rel;
     }
 
     public static class DependsOnBuilder extends DescribableEntityBuilder {

--- a/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/DependsOn.java
@@ -11,6 +11,10 @@ import lombok.Data;
 @Data
 public class DependsOn extends RootRelationship {
 
+    public DependsOn(){
+        super(null);
+    }
+    
     @Builder
     protected DependsOn(String description) {
         super(description);
@@ -19,5 +23,12 @@ public class DependsOn extends RootRelationship {
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);
+    }
+
+    public static RootRelationship getFallback(RootRelationship rel) {
+        return (rel == null) ? builder().build() : rel;
+    }
+
+    public static class DependsOnBuilder extends DescribableEntityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
@@ -15,7 +15,7 @@ public class HostedOn extends RootRelationship {
     public HostedOn() {
         super(null);
     }
-   
+
     @Builder
     protected HostedOn(String description) {
         super(description);

--- a/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/HostedOn.java
@@ -12,13 +12,24 @@ import lombok.Data;
 @Data
 public class HostedOn extends RootRelationship {
 
+    public HostedOn() {
+        super(null);
+    }
+   
     @Builder
     protected HostedOn(String description) {
         super(description);
     }
 
+    public static HostedOn getFallback(HostedOn rel) {
+        return (rel == null) ? new HostedOn() : rel;
+    }
+
     @Override
     public void accept(RelationshipVisitor v) {
         v.visit(this);
+    }
+
+    public static class HostedOnBuilder extends DescribableEntityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
@@ -15,5 +15,4 @@ public abstract class RootRelationship extends DescribableEntity implements Visi
     protected RootRelationship(String description) {
         super(description);
     }
-
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
@@ -22,4 +22,7 @@ public class RoutesTo extends RootRelationship {
     public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
+    
+    public static class RoutesToBuilder extends DescribableEntityBuilder {
+    }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RoutesTo.java
@@ -22,7 +22,7 @@ public class RoutesTo extends RootRelationship {
     public void accept(RelationshipVisitor v) {
         v.visit(this);
     }
-    
+
     public static class RoutesToBuilder extends DescribableEntityBuilder {
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/BlockStorageRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/BlockStorageRequirement.java
@@ -19,13 +19,11 @@ public class BlockStorageRequirement extends Requirement<AttachmentCapability, B
                                       Range occurrence,
                                       @Singular Set<BlockStorage> fulfillers,
                                       AttachesTo relationship) {
-        super(capability, occurrence, fulfillers, relationship);
+        super(AttachmentCapability.getFallback(capability), occurrence, fulfillers, relationship);
     }
 
-    public static BlockStorageRequirementBuilder builder(AttachmentCapability capability,
-                                                         AttachesTo relationship) {
+    public static BlockStorageRequirementBuilder builder(AttachesTo relationship) {
         return new BlockStorageRequirementBuilder()
-            .capability(capability)
             .relationship(relationship);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/ContainerHostRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/ContainerHostRequirement.java
@@ -19,7 +19,7 @@ public class ContainerHostRequirement extends Requirement<ContainerCapability, C
                                        Range occurrence,
                                        @Singular Set<ContainerRuntime> fulfillers,
                                        HostedOn relationship) {
-        super(ContainerCapability.getFallback(capability), occurrence, 
+        super(ContainerCapability.getFallback(capability), occurrence,
             fulfillers, HostedOn.getFallback(relationship));
     }
 

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/ContainerHostRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/ContainerHostRequirement.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.datatype.Range;
-import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.ContainerRuntime;
 import org.opentosca.toscana.model.relation.HostedOn;
 
@@ -20,13 +19,11 @@ public class ContainerHostRequirement extends Requirement<ContainerCapability, C
                                        Range occurrence,
                                        @Singular Set<ContainerRuntime> fulfillers,
                                        HostedOn relationship) {
-        super(capability, occurrence, fulfillers, relationship);
+        super(ContainerCapability.getFallback(capability), occurrence, 
+            fulfillers, HostedOn.getFallback(relationship));
     }
 
-    public static ContainerHostRequirementBuilder builder(ContainerCapability capability, 
-                                                         HostedOn relationship) {
-        return new ContainerHostRequirementBuilder()
-            .capability(capability)
-            .relationship(relationship);
+    public static ContainerHostRequirement getFallback(ContainerHostRequirement r) {
+        return (r == null) ? builder().build() : r;
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/DatabaseEndpointRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/DatabaseEndpointRequirement.java
@@ -2,12 +2,10 @@ package org.opentosca.toscana.model.requirement;
 
 import java.util.Set;
 
-import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.Database;
 import org.opentosca.toscana.model.relation.ConnectsTo;
-import org.opentosca.toscana.model.relation.HostedOn;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/DockerHostRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/DockerHostRequirement.java
@@ -19,13 +19,11 @@ public class DockerHostRequirement extends Requirement<DockerContainerCapability
                                     Range occurrence,
                                     @Singular Set<ContainerRuntime> fulfillers,
                                     HostedOn relationship) {
-        super(capability, occurrence, fulfillers, relationship);
+        super(DockerContainerCapability.getFallback(capability), occurrence,
+            fulfillers, HostedOn.getFallback(relationship));
     }
 
-    public static DockerHostRequirementBuilder builder(DockerContainerCapability capability, 
-                                                       HostedOn relationship) {
-        return new DockerHostRequirementBuilder()
-            .capability(capability)
-            .relationship(relationship);
+    public static DockerHostRequirement getFallback(DockerHostRequirement r) {
+        return (r == null) ? builder().build() : r;
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/EndpointRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/EndpointRequirement.java
@@ -2,13 +2,10 @@ package org.opentosca.toscana.model.requirement;
 
 import java.util.Set;
 
-import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
-import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.datatype.Range;
-import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.RootNode;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
 
 import lombok.Builder;
@@ -19,17 +16,15 @@ import lombok.Singular;
 public class EndpointRequirement extends Requirement<EndpointCapability, RootNode, RootRelationship> {
 
     @Builder
-    protected EndpointRequirement(EndpointCapability capability, 
-                                  Range occurrence, 
-                                  @Singular Set<RootNode> fulfillers, 
+    protected EndpointRequirement(EndpointCapability capability,
+                                  Range occurrence,
+                                  @Singular Set<RootNode> fulfillers,
                                   RootRelationship relationship) {
-        super(capability, occurrence, fulfillers, relationship);
+        super(capability, occurrence, fulfillers, DependsOn.getFallback(relationship));
     }
-    
-    public static EndpointRequirementBuilder builder(EndpointCapability capability, 
-                                                     RootRelationship relationship){
+
+    public static EndpointRequirementBuilder builder(EndpointCapability endpoint) {
         return new EndpointRequirementBuilder()
-            .capability(capability)
-            .relationship(relationship);
+            .capability(endpoint);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/HostRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/HostRequirement.java
@@ -15,17 +15,15 @@ import lombok.Singular;
 public class HostRequirement extends Requirement<ContainerCapability, Compute, HostedOn> {
 
     @Builder
-    protected HostRequirement(ContainerCapability capability, 
-                              Range occurrence, 
-                              @Singular Set<Compute> fulfillers, 
+    protected HostRequirement(ContainerCapability capability,
+                              Range occurrence,
+                              @Singular Set<Compute> fulfillers,
                               HostedOn relationship) {
-        super(capability, occurrence, fulfillers, relationship);
+        super(ContainerCapability.getFallback(capability), occurrence,
+            fulfillers, HostedOn.getFallback(relationship));
     }
-    
-    public static HostRequirementBuilder builder(ContainerCapability capability, HostedOn relationship){
-        return new HostRequirementBuilder()
-            .capability(capability)
-            .relationship(relationship);
-        
+
+    public static HostRequirement getFallback(HostRequirement host) {
+        return (host == null) ? HostRequirement.builder().build() : host;
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/MysqlDbmsRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/MysqlDbmsRequirement.java
@@ -19,13 +19,7 @@ public class MysqlDbmsRequirement extends Requirement<ContainerCapability, Mysql
                                    Range occurrence,
                                    @Singular Set<MysqlDbms> fulfillers,
                                    HostedOn relationship) {
-        super(capability, occurrence, fulfillers, relationship);
-    }
-
-    public static MysqlDbmsRequirementBuilder builder(ContainerCapability capability,
-                                                      HostedOn relationship) {
-        return new MysqlDbmsRequirementBuilder()
-            .capability(capability)
-            .relationship(relationship);
+        super(ContainerCapability.getFallback(capability), occurrence,
+            fulfillers, HostedOn.getFallback(relationship));
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
@@ -39,18 +39,16 @@ public class Requirement<CapabilityT extends Capability, NodeT extends RootNode,
      Note: Defaults to {@link Range#EXACTLY_ONCE}
      */
     protected final Range occurrence;
-
-    /**
-     The optional Nodes that have the required capability and shall be used to fulfill this requirement.
-     (TOSCA Simple Profile in YAML Version 1.1, p. 85)
-     */
-    protected Set<NodeT> fulfillers;
-
     /**
      The Relationship to construct when fulfilling the requirement.
      (TOSCA Simple Profile in YAML Version 1.1, p. 85)
      */
     protected final RelationshipT relationship;
+    /**
+     The optional Nodes that have the required capability and shall be used to fulfill this requirement.
+     (TOSCA Simple Profile in YAML Version 1.1, p. 85)
+     */
+    protected Set<NodeT> fulfillers;
 
     @Builder
     protected Requirement(CapabilityT capability,

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
@@ -58,7 +58,7 @@ public class Requirement<CapabilityT extends Capability, NodeT extends RootNode,
                           @Singular Set<NodeT> fulfillers,
                           RelationshipT relationship) {
         this.capability = Objects.requireNonNull(capability);
-        this.occurrence = (occurrence != null) ? occurrence : Range.EXACTLY_ONCE;
+        this.occurrence = (occurrence == null) ? Range.EXACTLY_ONCE : occurrence;
         this.fulfillers = Objects.requireNonNull(fulfillers);
         this.relationship = Objects.requireNonNull(relationship);
     }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/StorageRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/StorageRequirement.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
 
 import lombok.Builder;
@@ -19,13 +20,15 @@ public class StorageRequirement extends Requirement<StorageCapability, RootNode,
                                  Range occurrence,
                                  @Singular Set<RootNode> fulfillers,
                                  RootRelationship relationship) {
-        super(capability, occurrence, fulfillers, relationship);
+        super(StorageCapability.getFallback(capability), occurrence, fulfillers, relationship);
     }
 
-    public static StorageRequirementBuilder builder(StorageCapability capability,
-                                                    RootRelationship relationship) {
+    public static StorageRequirementBuilder builder(RootRelationship relationship) {
         return new StorageRequirementBuilder()
-            .capability(capability)
             .relationship(relationship);
+    }
+
+    public static StorageRequirement getFallback(StorageRequirement s) {
+        return (s == null) ? StorageRequirement.builder(new DependsOn()).build() : s;
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/WebServerRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/WebServerRequirement.java
@@ -19,13 +19,6 @@ public class WebServerRequirement extends Requirement<ContainerCapability, WebSe
                                    Range occurrence,
                                    @Singular Set<WebServer> fulfillers,
                                    HostedOn relationship) {
-        super(capability, occurrence, fulfillers, relationship);
-    }
-
-    public static WebServerRequirementBuilder builder(ContainerCapability capability,
-                                                      HostedOn relationship) {
-        return new WebServerRequirementBuilder()
-            .capability(capability)
-            .relationship(relationship);
+        super(ContainerCapability.getFallback(capability), occurrence, fulfillers, HostedOn.getFallback(relationship));
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
+++ b/server/src/main/java/org/opentosca/toscana/model/visitor/CapabilityVisitor.java
@@ -71,5 +71,4 @@ public interface CapabilityVisitor {
     default void visit(StorageCapability capability) {
         // noop
     }
-
 }

--- a/server/src/test/java/org/opentosca/toscana/plugins/cloudfoundry/CloudFoundryPluginTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/cloudfoundry/CloudFoundryPluginTest.java
@@ -19,16 +19,15 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.slf4j.LoggerFactory;
 
-import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.MANIFEST;
-import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.CLI_CREATE_SERVICE;
-import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.CLI_PUSH;
-import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.FILESUFFIX_DEPLOY;
-import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.FILEPRAEFIX_DEPLOY;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.CLI_CREATE_SERVICE;
+import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.CLI_PUSH;
+import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.FILEPRAEFIX_DEPLOY;
+import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.FILESUFFIX_DEPLOY;
+import static org.opentosca.toscana.plugins.cloudfoundry.CloudFoundryFileCreator.MANIFEST;
 
 public class CloudFoundryPluginTest extends BaseUnitTest {
 
@@ -92,10 +91,10 @@ public class CloudFoundryPluginTest extends BaseUnitTest {
 
     @Test
     public void getDeployScript() throws Exception {
-        File targetFile = new File(targetDir + "/output/scripts/",FILEPRAEFIX_DEPLOY + appName + 
+        File targetFile = new File(targetDir + "/output/scripts/", FILEPRAEFIX_DEPLOY + appName +
             FILESUFFIX_DEPLOY);
         String deployScript = FileUtils.readFileToString(targetFile);
-        String expectedOutput = String.format("#!/bin/sh\nsource util/*\ncheck \"cf\"\n%smy_db\n%s%s\n", 
+        String expectedOutput = String.format("#!/bin/sh\nsource util/*\ncheck \"cf\"\n%smy_db\n%s%s\n",
             CLI_CREATE_SERVICE, CLI_PUSH, appName);
 
         assertEquals(expectedOutput, deployScript);

--- a/server/src/test/java/org/opentosca/toscana/plugins/testdata/LampApp.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/testdata/LampApp.java
@@ -62,6 +62,7 @@ public class LampApp {
             .build();
         Compute computeNode = Compute
             .builder("server", osCapability, computeAdminEndpointCap, localStorage)
+            .host(createContainerCapability())
             .build();
         return computeNode;
     }

--- a/server/src/test/java/org/opentosca/toscana/plugins/testdata/LampApp.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/testdata/LampApp.java
@@ -4,18 +4,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
-import org.opentosca.toscana.model.capability.AttachmentCapability;
-import org.opentosca.toscana.model.capability.BindableCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
+import org.opentosca.toscana.model.capability.ContainerCapability.ContainerCapabilityBuilder;
 import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.capability.OsCapability;
-import org.opentosca.toscana.model.requirement.HostRequirement;
-import org.opentosca.toscana.model.requirement.BlockStorageRequirement;
-import org.opentosca.toscana.model.requirement.MysqlDbmsRequirement;
-import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.datatype.Port;
-import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.Apache;
 import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.MysqlDatabase;
@@ -26,7 +20,7 @@ import org.opentosca.toscana.model.operation.Operation;
 import org.opentosca.toscana.model.operation.OperationVariable;
 import org.opentosca.toscana.model.operation.StandardLifecycle;
 import org.opentosca.toscana.model.relation.AttachesTo;
-import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.BlockStorageRequirement;
 
 public class LampApp {
 
@@ -45,124 +39,107 @@ public class LampApp {
 
         testNodes.add(createComputeNode());
         testNodes.add(createMysqlDbms());
-        testNodes.add(createMsqlDatabase());
+        testNodes.add(createMysqlDatabase());
         testNodes.add(createApache());
         testNodes.add(createWebApplication());
     }
 
     private Compute createComputeNode() {
-        ContainerCapability containerCapability = createContainerCapabilityBuilder().build();
         AdminEndpointCapability computeAdminEndpointCap = AdminEndpointCapability
-            .builder("127.0.0.1")
-            .port(new Port(80)).build();
-        ScalableCapability scalableCapability = ScalableCapability.builder(Range.EXACTLY_ONCE).build();
-        BindableCapability bindableCapability = BindableCapability.builder().build();
-        AttachesTo attachesTo = AttachesTo.builder("mount").build();
-        AttachmentCapability attachmentCapability = AttachmentCapability.builder().build();
-
-        BlockStorageRequirement localStorage =
-            BlockStorageRequirement.builder(attachmentCapability, attachesTo).build();
-
-        OsCapability osCapability = OsCapability.builder()
+            .builder("127.0.0.1", new Port(80))
+            .build();
+        AttachesTo attachesTo = AttachesTo
+            .builder("mount")
+            .build();
+        BlockStorageRequirement localStorage = BlockStorageRequirement
+            .builder(attachesTo)
+            .build();
+        OsCapability osCapability = OsCapability
+            .builder()
             .distribution(OsCapability.Distribution.UBUNTU)
             .type(OsCapability.Type.LINUX)
             .version("16.04")
             .build();
-
-        Compute computeNode = Compute.builder("server", osCapability, computeAdminEndpointCap, scalableCapability,
-            bindableCapability, localStorage).host(containerCapability).build();
+        Compute computeNode = Compute
+            .builder("server", osCapability, computeAdminEndpointCap, localStorage)
+            .build();
         return computeNode;
     }
 
-    private ContainerCapability.ContainerCapabilityBuilder createContainerCapabilityBuilder() {
+    private ContainerCapability createContainerCapability() {
         Set<Class<? extends RootNode>> validSourceTypes = new HashSet<>();
         validSourceTypes.add(Compute.class);
         validSourceTypes.add(MysqlDbms.class);
 
-        ContainerCapability.ContainerCapabilityBuilder containerCapabilityBuilder = ContainerCapability.builder()
+        ContainerCapabilityBuilder containerCapabilityBuilder = ContainerCapability.builder()
             .memSizeInMB(1024)
             .diskSizeInMB(2000)
             .numCpus(1)
-            .name("host")
             .validSourceTypes(validSourceTypes);
 
-        return containerCapabilityBuilder;
+        return containerCapabilityBuilder.build();
     }
 
     private MysqlDbms createMysqlDbms() {
         Operation dbmsOperation = Operation.builder()
             .implementationArtifact("mysql_dbms/mysql_dbms_configure.sh")
-            .input(new OperationVariable("db_root_password")).build();
+            .input(new OperationVariable("db_root_password"))
+            .build();
 
         StandardLifecycle lifecycle = StandardLifecycle.builder()
             .configure(dbmsOperation)
             .build();
 
-        HostRequirement hostedOnRequirement = getHostedOnServerRequirement();
-
-        ContainerCapability.ContainerCapabilityBuilder capabilityBuilder = ContainerCapability.builder();
-
         MysqlDbms mysqlDbms = MysqlDbms.builder(
             "mysql_dbms",
-            "geheim",
-            hostedOnRequirement,
-            capabilityBuilder
-        ).port(3306).lifecycle(lifecycle).build();
+            "geheim")
+            .port(3306)
+            .lifecycle(lifecycle)
+            .build();
 
         return mysqlDbms;
     }
 
-    private MysqlDatabase createMsqlDatabase() {
-        DatabaseEndpointCapability dbEndpointCapability = DatabaseEndpointCapability.builder("127.0.0.1")
-            .port(new Port(3306))
+    private MysqlDatabase createMysqlDatabase() {
+        DatabaseEndpointCapability dbEndpointCapability = DatabaseEndpointCapability
+            .builder("127.0.0.1", new Port(3306))
             .build();
-        ContainerCapability dbContainerCapability = ContainerCapability.builder().build();
-        HostedOn hostedOn = HostedOn.builder().build();
-        MysqlDbmsRequirement requirement = MysqlDbmsRequirement.builder(dbContainerCapability, hostedOn)
-            .build();
-
-        MysqlDatabase mydb = MysqlDatabase.builder("my_db", "DBNAME", dbEndpointCapability,
-            requirement)
+        MysqlDatabase mydb = MysqlDatabase
+            .builder("my_db", "DBNAME", dbEndpointCapability)
             .build();
 
         return mydb;
     }
 
     private Apache createApache() {
-        ContainerCapability containerCapability = createContainerCapabilityBuilder().build();
-        DatabaseEndpointCapability apacheEndpoint = DatabaseEndpointCapability.builder("127.0.0.1")
-            .port(new Port(3306)).build();
-        AdminEndpointCapability adminEndpointCapability = AdminEndpointCapability.builder("127.0.0.1")
-            .port(new Port(80)).build();
-
-        HostRequirement hostedOnRequirement = getHostedOnServerRequirement();
+        ContainerCapability containerCapability = createContainerCapability();
+        DatabaseEndpointCapability apacheEndpoint = DatabaseEndpointCapability
+            .builder("127.0.0.1", new Port(3306))
+            .build();
+        AdminEndpointCapability adminEndpointCapability = AdminEndpointCapability
+            .builder("127.0.0.1", new Port(80))
+            .build();
 
         Apache webServer = Apache.builder(
             "apache_web_server",
-            hostedOnRequirement,
             containerCapability,
             apacheEndpoint,
-            adminEndpointCapability
-        ).databaseEndpoint(apacheEndpoint).build();
+            adminEndpointCapability)
+            .databaseEndpoint(apacheEndpoint)
+            .build();
 
         return webServer;
     }
 
-    private HostRequirement getHostedOnServerRequirement() {
-        ContainerCapability hostCapability = ContainerCapability.builder().name("server").build();
-
-        return HostRequirement.builder(
-            hostCapability,
-            HostedOn.builder().build()
-        ).build();
-    }
-
     private WebApplication createWebApplication() {
-        EndpointCapability endpointCapability = EndpointCapability.builder("127.0.0.1", new Port(80)).build();
+        EndpointCapability endpointCapability = EndpointCapability
+            .builder("127.0.0.1", new Port(80))
+            .build();
         Set<String> appDependencies = new HashSet<>();
         appDependencies.add("my_app/myphpapp.php");
         appDependencies.add("my_app/mysql-credentials.php");
-        Operation appCreate = Operation.builder().implementationArtifact("my_app/create_myphpapp.sh")
+        Operation appCreate = Operation.builder()
+            .implementationArtifact("my_app/create_myphpapp.sh")
             .dependencies(appDependencies)
             .build();
 
@@ -175,7 +152,8 @@ public class LampApp {
         dbPort.setValue("3306");
         appInputs.add(dbPort);
 
-        Operation appConfigure = Operation.builder().implementationArtifact("my_app/configure_myphpapp.sh")
+        Operation appConfigure = Operation.builder()
+            .implementationArtifact("my_app/configure_myphpapp.sh")
             .inputs(appInputs)
             .build();
 
@@ -183,7 +161,8 @@ public class LampApp {
             .create(appCreate)
             .configure(appConfigure)
             .build();
-        WebApplication webApplication = WebApplication.builder("my_app", endpointCapability)
+        WebApplication webApplication = WebApplication
+            .builder("my_app", endpointCapability)
             .standardLifecycle(webAppLifecycle)
             .build();
 

--- a/server/src/test/java/org/opentosca/toscana/plugins/testdata/TestEffectiveModels.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/testdata/TestEffectiveModels.java
@@ -5,26 +5,19 @@ import java.util.Set;
 
 import org.opentosca.toscana.model.EffectiveModel;
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
-import org.opentosca.toscana.model.capability.AttachmentCapability;
-import org.opentosca.toscana.model.capability.BindableCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.DockerContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.capability.OsCapability;
-import org.opentosca.toscana.model.capability.ScalableCapability;
-import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.datatype.Port;
-import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.model.node.ContainerRuntime;
 import org.opentosca.toscana.model.node.DockerApplication;
 import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.relation.AttachesTo;
-import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.BlockStorageRequirement;
 import org.opentosca.toscana.model.requirement.DockerHostRequirement;
 import org.opentosca.toscana.model.requirement.EndpointRequirement;
-import org.opentosca.toscana.model.requirement.HostRequirement;
 import org.opentosca.toscana.model.requirement.StorageRequirement;
 
 import com.google.common.collect.Sets;
@@ -34,48 +27,58 @@ public class TestEffectiveModels {
     public static EffectiveModel getSingleComputeNodeModel() {
         Set<Class<? extends RootNode>> validSourceTypes = new HashSet<>();
         validSourceTypes.add(Compute.class);
-        ContainerCapability.ContainerCapabilityBuilder containerCapabilityBuilder = ContainerCapability.builder()
+        ContainerCapability host = ContainerCapability.builder()
             .memSizeInMB(1024)
             .diskSizeInMB(2000)
             .numCpus(1)
-            .name("host")
-            .validSourceTypes(validSourceTypes);
-
-        ContainerCapability containerCapability = containerCapabilityBuilder.build();
+            .validSourceTypes(validSourceTypes)
+            .build();
 
         AdminEndpointCapability computeAdminEndpointCap = AdminEndpointCapability
-            .builder("127.0.0.1")
-            .port(new Port(80)).build();
-        ScalableCapability scalableCapability = ScalableCapability.builder(Range.EXACTLY_ONCE).build();
-        BindableCapability bindableCapability = BindableCapability.builder().build();
-        AttachesTo attachesTo = AttachesTo.builder("mount").build();
-        AttachmentCapability attachmentCapability = AttachmentCapability.builder().build();
-        BlockStorageRequirement blockStorageRequirement
-            = BlockStorageRequirement.builder(attachmentCapability, attachesTo).build();
-        OsCapability os = OsCapability.builder().type(OsCapability.Type.WINDOWS).build();
-        Compute computeNode = Compute.builder("server", os, computeAdminEndpointCap, scalableCapability,
-            bindableCapability, blockStorageRequirement).host(containerCapability).build();
+            .builder("127.0.0.1", new Port(80))
+            .build();
+        AttachesTo attachesTo = AttachesTo
+            .builder("mount")
+            .build();
+        BlockStorageRequirement blockStorageRequirement = BlockStorageRequirement
+            .builder(attachesTo)
+            .build();
+        OsCapability os = OsCapability.builder()
+            .type(OsCapability.Type.WINDOWS)
+            .build();
+        Compute computeNode = Compute
+            .builder("server", os, computeAdminEndpointCap, blockStorageRequirement)
+            .host(host)
+            .build();
         return new EffectiveModel(Sets.newHashSet(computeNode));
     }
 
     public static EffectiveModel getMinimalDockerModel() {
-        DockerContainerCapability containerCapability = DockerContainerCapability.builder().name("host").build();
-        ScalableCapability scalableCapability = ScalableCapability.builder(Range.EXACTLY_ONCE).build();
-        HostRequirement requirement = HostRequirement.builder(containerCapability, HostedOn.builder().build()).build();
-        ContainerRuntime dockerRuntime
-            = ContainerRuntime.builder("dockerRuntime", requirement,
-            containerCapability, scalableCapability).build();
-        HostedOn hostedOn = HostedOn.builder().build();
-        DockerHostRequirement host = DockerHostRequirement.builder(containerCapability, hostedOn)
+        DockerContainerCapability containerCapability = DockerContainerCapability.builder().build();
+        ContainerRuntime dockerRuntime = ContainerRuntime
+            .builder("dockerRuntime").
+                containerHost(containerCapability).
+                build();
+        DockerHostRequirement host = DockerHostRequirement
+            .builder()
             .fulfiller(dockerRuntime)
             .build();
-        EndpointCapability endpointCapability = EndpointCapability.builder("127.0.0.1", new Port(80)).build();
-        EndpointRequirement network = EndpointRequirement.builder(endpointCapability, hostedOn).build();
-        StorageCapability storageCapability = StorageCapability.builder().build();
-        AttachesTo attachesTo = AttachesTo.builder("/").build();
-        StorageRequirement storage = StorageRequirement.builder(storageCapability, attachesTo).build();
-        DockerApplication simpleTaskApp
-            = DockerApplication.builder(host, "simpleTaskApp", network, storage).build();
+        EndpointCapability endpointCapability = EndpointCapability
+            .builder("127.0.0.1", new Port(80))
+            .build();
+        EndpointRequirement network = EndpointRequirement.
+            builder(endpointCapability)
+            .build();
+        AttachesTo attachesTo = AttachesTo
+            .builder("/")
+            .build();
+        StorageRequirement storage = StorageRequirement
+            .builder(attachesTo)
+            .build();
+        DockerApplication simpleTaskApp = DockerApplication
+            .builder("simpleTaskApp", network)
+            .host(host)
+            .build();
         return new EffectiveModel(Sets.newHashSet(simpleTaskApp, dockerRuntime));
     }
 


### PR DESCRIPTION
While building the converter I had to change some aspects of the model, e.g.:
- Make it more convenient to construct entities - Entities which can be constructed without any parameter are not required anymore as parameter in the builder() method
  - the test model instances (minimal-docker and lamp) are adapted aswell
- No Builder anymore required as parameter for other builders
- Builder classes follow the inheritance topology, too (needed for the converter visitors)
- minor fixes here and there
- code reformat