### PR TITLE
Update Codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,20 @@
+
+coverage:
+  range: 50..75
+  round: down
+  precision: 2
+  status:
+    patch:
+      default:
+        target: 60%
+        threshold: 5%
+        base: auto
+    project:
+      default:
+        target: 50%
+        threshold: 5%
+        base: auto
+
 comment: 
   layout: "reach, diff, flags, files" 
   behavior: default 


### PR DESCRIPTION
Coverage Requirements have been reduced in this PR. This prevents the Codecov checks to always fail.
- PR Diff now is: 60% to pass
- Global Coverage is: 50% to pass