### PR TITLE
Implement basic Pod grouping

### DIFF
--- a/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampIT.java
@@ -40,7 +40,7 @@ public class KubernetesLampIT extends BaseTransformTest {
     @Override
     protected void onSuccess(File outputDir) throws Exception {
         //Comment out the sleep command to allow the interruption of the test before the files get deleted
-        Thread.sleep(10000+0);
+        Thread.sleep(10000);
         //Do Nothing
     }
 

--- a/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampIT.java
@@ -40,7 +40,7 @@ public class KubernetesLampIT extends BaseTransformTest {
     @Override
     protected void onSuccess(File outputDir) throws Exception {
         //Comment out the sleep command to allow the interruption of the test before the files get deleted
-        Thread.sleep(10000);
+        Thread.sleep(10000+0);
         //Do Nothing
     }
 

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLifecycle.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLifecycle.java
@@ -17,6 +17,7 @@ import org.opentosca.toscana.plugins.kubernetes.docker.image.PushingImageBuilder
 import org.opentosca.toscana.plugins.kubernetes.docker.mapper.BaseImageMapper;
 import org.opentosca.toscana.plugins.kubernetes.docker.util.DockerRegistryCredentials;
 import org.opentosca.toscana.plugins.kubernetes.exceptions.UnsupportedOsTypeException;
+import org.opentosca.toscana.plugins.kubernetes.model.Pod;
 import org.opentosca.toscana.plugins.kubernetes.util.KubernetesNodeContainer;
 import org.opentosca.toscana.plugins.kubernetes.util.NodeStack;
 import org.opentosca.toscana.plugins.kubernetes.visitor.check.NodeTypeCheckVisitor;
@@ -238,7 +239,7 @@ public class KubernetesLifecycle extends AbstractLifecycle {
     private void createKubernetesResources() {
         logger.info("Creating Kubernetes Resource Descriptions");
 
-        ResourceFileCreator creator = new ResourceFileCreator(this.stacks);
+        ResourceFileCreator creator = new ResourceFileCreator(Pod.getPods(this.stacks));
 
         StringBuilder complete = new StringBuilder();
         try {

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreator.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreator.java
@@ -1,8 +1,9 @@
 package org.opentosca.toscana.plugins.kubernetes;
 
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.Set;
 
+import org.opentosca.toscana.plugins.kubernetes.model.Pod;
 import org.opentosca.toscana.plugins.kubernetes.model.ResourceDeployment;
 import org.opentosca.toscana.plugins.kubernetes.model.ResourceService;
 import org.opentosca.toscana.plugins.kubernetes.util.NodeStack;
@@ -12,22 +13,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ResourceFileCreator {
-    private final static Logger logger = LoggerFactory.getLogger(ResourceFileCreator.class);
-    private Set<NodeStack> stacks;
+
+    private Collection<Pod> pods;
     private HashMap<String, String> result;
 
-    public ResourceFileCreator(Set<NodeStack> stacks) {
-        this.stacks = stacks;
+    public ResourceFileCreator(Collection<Pod> pods) {
+        this.pods = pods;
     }
 
     public HashMap<String, String> create() throws JsonProcessingException {
         result = new HashMap<>();
-        for (NodeStack stack : stacks) {
+        for (Pod pod : pods) {
             ResourceDeployment replicationController
-                = new ResourceDeployment(stack);
-            ResourceService service = new ResourceService(stack);
-            result.put(stack.getStackName() + "-deployment", replicationController.build().toYaml());
-            result.put(stack.getStackName() + "-service", service.build().toYaml());
+                = new ResourceDeployment(pod);
+            ResourceService service = new ResourceService(pod);
+            result.put(pod.getName() + "-deployment", replicationController.build().toYaml());
+            result.put(pod.getName() + "-service", service.build().toYaml());
         }
         return result;
     }

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Pod.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Pod.java
@@ -1,0 +1,53 @@
+package org.opentosca.toscana.plugins.kubernetes.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.opentosca.toscana.model.node.Compute;
+import org.opentosca.toscana.plugins.kubernetes.util.NodeStack;
+
+public class Pod {
+    private List<NodeStack> containers;
+
+    private Set<Port> ports;
+    
+    public Pod(List<NodeStack> containers) {
+        this.ports = new HashSet<>();
+        this.containers = containers;
+        
+        this.containers.forEach(e -> this.ports.addAll(e.getOpenPorts()));
+    }
+
+    public List<NodeStack> getContainers() {
+        return containers;
+    }
+
+    public Set<Port> getPorts() {
+        return ports;
+    }
+
+    public String getName() {
+        //TODO find better mechanism to name the pod
+        return containers.get(0).getStackName();
+    }
+
+    public static List<Pod> getPods(Collection<NodeStack> stacks) {
+        //Group Node Stacks
+        Map<Compute, List<NodeStack>> stackMap = new HashMap<>();
+        for (NodeStack stack : stacks) {
+            Compute computeNode = stack.getComputeNode();
+            stackMap.computeIfAbsent(computeNode, k -> new ArrayList<>());
+            stackMap.get(computeNode).add(stack);
+        }
+
+        //Convert NodeStacks to Pods
+        List<Pod> pods = new ArrayList<>();
+        stackMap.forEach((k, v) -> pods.add(new Pod(v)));
+        return pods;
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Pod.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Pod.java
@@ -33,7 +33,7 @@ public class Pod {
 
     public String getName() {
         //TODO find better mechanism to name the pod
-        return containers.get(0).getStackName();
+        return containers.get(0).getCleanStackName();
     }
 
     public static List<Pod> getPods(Collection<NodeStack> stacks) {

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Port.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Port.java
@@ -1,0 +1,26 @@
+package org.opentosca.toscana.plugins.kubernetes.model;
+
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+
+public class Port {
+    private int port;
+
+    public Port(int port) {
+        this.port = port;
+    }
+
+    public int getPort() {
+        return port;
+    }
+    
+    public ServicePort toServicePort() {
+        return new ServicePortBuilder().withPort(port).build();
+    }
+    
+    public ContainerPort toContainerPort() {
+        return new ContainerPortBuilder().withContainerPort(port).build();
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Port.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/Port.java
@@ -7,20 +7,26 @@ import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 
 public class Port {
     private int port;
+    private String namePrefix;
 
-    public Port(int port) {
+    public Port(int port, String namePrefix) {
         this.port = port;
+        this.namePrefix = namePrefix;
     }
 
     public int getPort() {
         return port;
     }
-    
-    public ServicePort toServicePort() {
-        return new ServicePortBuilder().withPort(port).build();
+
+    public String getName() {
+        return namePrefix + "-" + port;
     }
-    
+
+    public ServicePort toServicePort() {
+        return new ServicePortBuilder().withPort(port).withName(getName()).build();
+    }
+
     public ContainerPort toContainerPort() {
-        return new ContainerPortBuilder().withContainerPort(port).build();
+        return new ContainerPortBuilder().withName(getName()).withContainerPort(port).build();
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/ResourceDeployment.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/ResourceDeployment.java
@@ -17,7 +17,7 @@ public class ResourceDeployment {
 
     public ResourceDeployment(Pod stack) {
         this.pod = stack;
-        this.name = stack.getName().replaceAll("_", "-");
+        this.name = stack.getName();
     }
 
     public ResourceDeployment build() {
@@ -26,6 +26,7 @@ public class ResourceDeployment {
         pod.getContainers().forEach(e -> {
             Container container = new ContainerBuilder()
                 .withImage(e.getDockerImageTag().get())
+                .withName(e.getCleanStackName())
                 .addAllToPorts(e.getOpenPorts().stream().map(Port::toContainerPort).collect(Collectors.toList()))
                 .build();
             

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/ResourceService.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/model/ResourceService.java
@@ -1,5 +1,7 @@
 package org.opentosca.toscana.plugins.kubernetes.model;
 
+import java.util.stream.Collectors;
+
 import org.opentosca.toscana.plugins.kubernetes.util.NodeStack;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -9,12 +11,12 @@ import io.fabric8.kubernetes.client.internal.SerializationUtils;
 
 public class ResourceService {
     private final String name;
-    private NodeStack stack;
+    private Pod pod;
     private Service service;
 
-    public ResourceService(NodeStack stack) {
-        this.stack = stack;
-        this.name = stack.getStackName().replaceAll("_", "-");
+    public ResourceService(Pod pod) {
+        this.pod = pod;
+        this.name = pod.getName().replaceAll("_", "-");
     }
 
     public ResourceService build() {
@@ -24,7 +26,7 @@ public class ResourceService {
             .addToLabels("app", name + "-service")
             .endMetadata()
             .withNewSpec()
-            .addAllToPorts(stack.getOpenServicePorts())
+            .addAllToPorts(pod.getPorts().stream().map(Port::toServicePort).collect(Collectors.toList()))
             .addToSelector("app", name)
             .withType("NodePort")
             .endSpec()

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/util/NodeStack.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/util/NodeStack.java
@@ -80,7 +80,7 @@ public class NodeStack {
     }
 
     public List<Port> getOpenPorts() {
-        return openPorts.stream().map(Port::new).collect(Collectors.toList());
+        return openPorts.stream().map(e -> new Port(e, this.getCleanStackName())).collect(Collectors.toList());
     }
 
     public Optional<String> getDockerfilePath() {
@@ -94,16 +94,20 @@ public class NodeStack {
     public Optional<String> getDockerImageTag() {
         return Optional.ofNullable(dockerImageTag);
     }
-    
+
     public String getStackName() {
         return stackNodes.get(0).getNode().getNodeName();
+    }
+
+    public String getCleanStackName() {
+        return getStackName().replaceAll("_", "-");
     }
 
     public Compute getComputeNode() {
         return (Compute) this.stackNodes.stream().filter(e -> e.getNode() instanceof Compute)
             .findFirst().orElseThrow(IllegalArgumentException::new).getNode();
     }
-    
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/util/NodeStack.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/util/NodeStack.java
@@ -6,9 +6,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.opentosca.toscana.core.transformation.TransformationContext;
+import org.opentosca.toscana.model.node.Compute;
 import org.opentosca.toscana.plugins.kubernetes.docker.mapper.BaseImageMapper;
+import org.opentosca.toscana.plugins.kubernetes.model.Port;
 import org.opentosca.toscana.plugins.kubernetes.visitor.imgtransform.DockerfileBuildingVisitor;
 import org.opentosca.toscana.plugins.kubernetes.visitor.imgtransform.ImageMappingVisitor;
 
@@ -76,6 +79,10 @@ public class NodeStack {
         return Collections.unmodifiableList(ports);
     }
 
+    public List<Port> getOpenPorts() {
+        return openPorts.stream().map(Port::new).collect(Collectors.toList());
+    }
+
     public Optional<String> getDockerfilePath() {
         return Optional.ofNullable(dockerfilePath);
     }
@@ -92,6 +99,11 @@ public class NodeStack {
         return stackNodes.get(0).getNode().getNodeName();
     }
 
+    public Compute getComputeNode() {
+        return (Compute) this.stackNodes.stream().filter(e -> e.getNode() instanceof Compute)
+            .findFirst().orElseThrow(IllegalArgumentException::new).getNode();
+    }
+    
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreatorTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreatorTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.fail;
 
 public class ResourceFileCreatorTest extends BaseUnitTest {
     private String appName = "my-app";
-    private String appServiceName = "my_app-service";
-    private String appDeploymentName = "my_app-deployment";
+    private String appServiceName = "my-app-service";
+    private String appDeploymentName = "my-app-deployment";
 
     @Test
     public void testReplicationControllerCreation() {
@@ -57,7 +57,7 @@ public class ResourceFileCreatorTest extends BaseUnitTest {
         ArrayList<Map> containers = (ArrayList<Map>) ((Map) template.get("spec")).get("containers");
         Map container = containers.get(0);
         assertEquals(appName, container.get("image"));
-//        assertEquals(appName, container.get("name"));
+        assertEquals(appName, container.get("name"));
     }
 
     private void metadataTest(String name, Map templateMetadata) {

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreatorTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreatorTest.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.opentosca.toscana.core.BaseUnitTest;
+import org.opentosca.toscana.plugins.kubernetes.model.Pod;
 import org.opentosca.toscana.plugins.kubernetes.model.TestNodeStacks;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -21,7 +22,7 @@ public class ResourceFileCreatorTest extends BaseUnitTest {
 
     @Test
     public void testReplicationControllerCreation() {
-        ResourceFileCreator resourceFileCreator = new ResourceFileCreator(TestNodeStacks.getLampNodeStacks());
+        ResourceFileCreator resourceFileCreator = new ResourceFileCreator(Pod.getPods(TestNodeStacks.getLampNodeStacks()));
 
         HashMap<String, String> result = null;
         try {
@@ -56,7 +57,7 @@ public class ResourceFileCreatorTest extends BaseUnitTest {
         ArrayList<Map> containers = (ArrayList<Map>) ((Map) template.get("spec")).get("containers");
         Map container = containers.get(0);
         assertEquals(appName, container.get("image"));
-        assertEquals(appName, container.get("name"));
+//        assertEquals(appName, container.get("name"));
     }
 
     private void metadataTest(String name, Map templateMetadata) {


### PR DESCRIPTION
This PR Implements the Grouping of pods (by compute node). i.e. All containers that originally belonged to the same compute node will land in the same pod.

This feature will need updating once we migrate to DockerApplications instead of nodestacks, but for now it works.

This also has been the last step to allow the transformation of the Common LAMP model.
This has been verified! Deployment works!