### PR TITLE
Relationship type detection

### DIFF
--- a/server/src/integration/java/org/opentosca/toscana/core/csar/CsarServiceImplIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/core/csar/CsarServiceImplIT.java
@@ -36,8 +36,6 @@ public class CsarServiceImplIT extends BaseSpringIntegrationTest {
     public void submitCsar() throws Exception {
         File file = TestCsars.VALID_MINIMAL_DOCKER;
         InputStream stream = new FileInputStream(file);
-//        when(csarDao.create(identifier, stream)).thenReturn(csar);
-//        when(csarDao.getContentDir(csar)).thenReturn(tmpdir);
 
         Csar result = csarService.submitCsar(identifier, stream);
         assertEquals(csar, result);

--- a/server/src/main/java/org/opentosca/toscana/core/parse/converter/TypeWrapper.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/converter/TypeWrapper.java
@@ -49,7 +49,7 @@ public class TypeWrapper {
     private static <T> T wrap(MappingEntity entity, Class type) {
         try {
             if (Modifier.isAbstract(type.getModifiers())) {
-                type = KeyReflector.detectRealCapabilityType(entity, type);
+                type = KeyReflector.detectRealSubtype(entity, type);
             }
             T node = (T) ConstructorUtils.invokeConstructor(type, entity);
             return node;

--- a/server/src/main/java/org/opentosca/toscana/core/parse/model/CollectionEntity.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/model/CollectionEntity.java
@@ -1,0 +1,10 @@
+package org.opentosca.toscana.core.parse.model;
+
+import java.util.Collection;
+
+public interface CollectionEntity {
+    
+    Collection<Entity> getChildren();
+    
+    void addChild(Entity entity);
+}

--- a/server/src/main/java/org/opentosca/toscana/core/parse/model/Entity.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/model/Entity.java
@@ -1,21 +1,28 @@
 package org.opentosca.toscana.core.parse.model;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import org.opentosca.toscana.core.parse.converter.TypeConverter;
+import org.opentosca.toscana.core.parse.converter.util.AttributeNotSetException;
 import org.opentosca.toscana.model.BaseToscaElement;
 import org.opentosca.toscana.model.EntityId;
 import org.opentosca.toscana.model.util.ToscaKey;
+
+import org.slf4j.Logger;
 
 public abstract class Entity implements Comparable<Entity> {
 
     protected final ServiceGraph graph;
     private final EntityId id;
+    private final Logger logger;
 
     public Entity(EntityId id, ServiceGraph graph) {
         this.id = id;
         this.graph = graph;
+        this.logger = graph.getLog().getLogger(getClass());
     }
 
     public <V> void setValue(ToscaKey<V> key, V value) {
@@ -33,20 +40,45 @@ public abstract class Entity implements Comparable<Entity> {
         return id.getName();
     }
 
-    public Optional<Entity> getChild(String key) {
-        return graph.getChild(this, key);
+    public Optional<Entity> getChild(ToscaKey<?> key) {
+        Entity source = this;
+        if (key.getPredecessor().isPresent()) {
+            Optional<Entity> intermediateEntity = getChild(key.getPredecessor().get());
+            if (intermediateEntity.isPresent()) {
+                source = intermediateEntity.get();
+            } else {
+                return Optional.empty();
+            }
+        }
+        return source.getChild(key.name);
     }
 
-    public Optional<Entity> getChild(ToscaKey key) {
-        return graph.getChild(this, key);
+    /**
+     Returns the associated child for given name and source entity.
+
+     @return null if no child associated with given name was found
+     */
+    public Optional<Entity> getChild(String key) {
+        for (Connection connection : graph.outgoingEdgesOf(this)) {
+            if (connection.getKey().equals(key)) {
+                return Optional.of(connection.getTarget());
+            }
+        }
+        return Optional.empty();
     }
 
     public Entity getChildOrThrow(String key) {
-        return graph.getChildOrThrow(this, key);
+        Optional<Entity> optionalEntity = getChild(key);
+        return optionalEntity.orElseThrow(() -> new IllegalStateException(
+            String.format("Entity '%s' is referenced but does not exist", getId().descend(key))
+        ));
     }
 
     public Entity getChildOrThrow(ToscaKey key) {
-        return graph.getChildOrThrow(this, key);
+        Optional<Entity> optionalEntity = getChild(key);
+        return optionalEntity.orElseThrow(() -> new IllegalStateException(
+            String.format("Entity '%s' is referenced but does not exist", getId().descend(key))
+        ));
     }
 
     public EntityId getId() {
@@ -61,9 +93,37 @@ public abstract class Entity implements Comparable<Entity> {
         return id.equals(that.id);
     }
 
-    @Override
-    public int hashCode() {
-        return id.hashCode();
+    public <T> Collection<T> getCollection(ToscaKey<T> key) {
+        Set<T> values = new HashSet<>();
+        Optional<Entity> child = getChild(key);
+        if (child.isPresent()) {
+            for (Entity grandChild : child.get().getChildren()) {
+                try {
+                    T value = TypeConverter.convert(grandChild, key);
+                    values.add(value);
+                } catch (AttributeNotSetException e) {
+                    logger.warn("Trying to access an unset attribute - skipping.", e);
+                }
+            }
+        }
+        return values;
+    }
+
+    public ServiceGraph getGraph() {
+        return graph;
+    }
+
+    public Collection<Entity> getChildren() {
+        Set<Entity> children = new HashSet<>();
+        for (Connection connection : graph.outgoingEdgesOf(this)) {
+            children.add(connection.getTarget());
+        }
+        return children;
+    }
+
+    public Entity getParent() {
+        EntityId parentId = getId().ascend();
+        return graph.getEntity(parentId).get();
     }
 
     @Override
@@ -71,19 +131,8 @@ public abstract class Entity implements Comparable<Entity> {
         return id.compareTo(other.id);
     }
 
-    public Collection<Entity> getChildren() {
-        return graph.getChildren(this);
-    }
-
-    public <T> Set<T> getCollection(ToscaKey<T> key) {
-        return graph.getCollection(this, key);
-    }
-
-    public ServiceGraph getGraph() {
-        return graph;
-    }
-
-    public Entity getParent() {
-        return graph.getParent(this);
+    @Override
+    public int hashCode() {
+        return id.hashCode();
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/core/parse/model/SequenceEntity.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/model/SequenceEntity.java
@@ -1,10 +1,10 @@
 package org.opentosca.toscana.core.parse.model;
 
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 
 import org.opentosca.toscana.model.EntityId;
 
@@ -12,7 +12,7 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 
-public class SequenceEntity extends Entity {
+public class SequenceEntity extends Entity implements CollectionEntity {
 
     private final SequenceNode sequenceNode;
 
@@ -33,19 +33,35 @@ public class SequenceEntity extends Entity {
     @Override
     public List<Entity> getChildren() {
         List<Entity> children = new ArrayList<>();
-        Set<Entity> entities = graph.getChildren(this);
+        Collection<Entity> entities = super.getChildren();
         List<Entity> orderedEntities = new LinkedList<>(entities);
+        // TODO sort per connection name, not entity name. 
         orderedEntities.sort((b1, b2) -> b1.getName().compareTo(b2.getName()));
         for (Entity entity : orderedEntities) {
-            if (entity instanceof ScalarEntity) {
-                children.add(entity);
-            } else {
-                Iterator<Entity> it = entity.getChildren().iterator();
-                Entity child = it.next();
-                children.add(child);
-            }
+            children.add(entity);
         }
         return children;
+    }
+
+    /**
+     Returns the associated child for given name and source entity.
+
+     @return null if no child associated with given name was found
+     */
+    @Override
+    public Optional<Entity> getChild(String key) {
+        for (Connection connection : graph.outgoingEdgesOf(this)) {
+            Entity child = connection.getTarget();
+            if (key.equals(child.getName())) {
+                return Optional.of(child);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void addChild(Entity entity) {
+        // TODO
     }
 
     @Override

--- a/server/src/main/java/org/opentosca/toscana/model/BaseToscaElement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/BaseToscaElement.java
@@ -34,7 +34,7 @@ public abstract class BaseToscaElement {
         return value;
     }
 
-    public <T> Set<T> getCollection(ToscaKey<T> key) {
+    public <T> Collection<T> getCollection(ToscaKey<T> key) {
         return mappingEntity.getCollection(key);
     }
 
@@ -62,14 +62,14 @@ public abstract class BaseToscaElement {
             mappingEntity.setValue(key, value);
         }
     }
-
+    
     public String getEntityName() {
         return name;
     }
 
     /**
      Returns the underlying raw entity.
-     Danger: Do not use this outside of the rename.
+     Danger: Do not use this outside of the converter.
      Your fellow developers will find you and hunt you down.
      */
     public MappingEntity getBackingEntity() {

--- a/server/src/main/java/org/opentosca/toscana/model/EntityId.java
+++ b/server/src/main/java/org/opentosca/toscana/model/EntityId.java
@@ -72,7 +72,9 @@ public class EntityId implements Comparable<EntityId> {
 
     public EntityId ascend() {
         int pathSize = this.path.size();
-        pathSize = (pathSize < 2) ? 2 : pathSize;
+        if (pathSize < 2) {
+            throw new IllegalStateException("Id has no parent - can not ascend further");
+        }
         List<String> parentPath = this.path.subList(0, pathSize - 1);
         return new EntityId(parentPath);
     }
@@ -83,7 +85,7 @@ public class EntityId implements Comparable<EntityId> {
         for (int i = 0; i < path.size(); i++) {
             representation += path.get(i);
             if (i != path.size() - 1) {
-                representation += " > ";
+                representation += ".";
             }
         }
         return representation;

--- a/server/src/main/java/org/opentosca/toscana/model/artifact/Artifact.java
+++ b/server/src/main/java/org/opentosca/toscana/model/artifact/Artifact.java
@@ -22,7 +22,7 @@ public class Artifact extends DescribableEntity {
      The path (relative or absolute) which can be used to locate the artifact’s filePath.
      */
     public static ToscaKey<String> FILE_PATH = new ToscaKey<>("file")
-        .required(true);
+        .required();
 
     /**
      The optional external repository that contains the artifact.

--- a/server/src/main/java/org/opentosca/toscana/model/artifact/Repository.java
+++ b/server/src/main/java/org/opentosca/toscana/model/artifact/Repository.java
@@ -22,7 +22,7 @@ public class Repository extends DescribableEntity {
     /**
      The URL used to access the repository.
      */
-    public static final ToscaKey<String> URL = new ToscaKey<>("url").required(true);
+    public static final ToscaKey<String> URL = new ToscaKey<>("url").required();
 
     /**
      The optional Credential used to authorize access to the repository.

--- a/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/Capability.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.capability;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
@@ -43,7 +44,7 @@ public abstract class Capability extends BaseToscaElement implements VisitableCa
      @return {@link #VALID_SOURCE_TYPES}
      */
     public Set<Class<? extends RootNode>> getValidSourceTypes() {
-        return getCollection(VALID_SOURCE_TYPES);
+        return new HashSet<>(getCollection(VALID_SOURCE_TYPES));
     }
 
     public Range getOccurrence() {

--- a/server/src/main/java/org/opentosca/toscana/model/datatype/Credential.java
+++ b/server/src/main/java/org/opentosca/toscana/model/datatype/Credential.java
@@ -37,7 +37,7 @@ public class Credential extends BaseToscaElement {
      <p>
      (TOSCA Simple Profile in YAML Version 1.1, p. 140)
      */
-    public static ToscaKey<String> TOKEN = new ToscaKey<>("token").required(true);
+    public static ToscaKey<String> TOKEN = new ToscaKey<>("token").required();
     /**
      Map of protocol-specific keys or assertions. Might be empty.
      <p>

--- a/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
@@ -5,13 +5,16 @@ import java.util.Set;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.model.capability.AdminEndpointCapability;
+import org.opentosca.toscana.model.capability.AttachmentCapability;
 import org.opentosca.toscana.model.capability.BindableCapability;
 import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.OsCapability;
 import org.opentosca.toscana.model.capability.ScalableCapability;
 import org.opentosca.toscana.model.datatype.NetworkInfo;
 import org.opentosca.toscana.model.datatype.PortInfo;
+import org.opentosca.toscana.model.relation.AttachesTo;
 import org.opentosca.toscana.model.requirement.BlockStorageRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -64,8 +67,8 @@ public class Compute extends RootNode {
         .type(ScalableCapability.class);
     public static ToscaKey<BindableCapability> BINDING = new ToscaKey<>(CAPABILITIES, "binding")
         .type(BindableCapability.class);
-    public static ToscaKey<BlockStorageRequirement> LOCAL_STORAGE = new ToscaKey<>(REQUIREMENTS, "local_storage")
-        .required(true).type(BlockStorageRequirement.class);
+    public static ToscaKey<BlockStorageRequirement> LOCAL_STORAGE = new RequirementKey<>("local_storage")
+        .types(AttachmentCapability.class, BlockStorage.class, AttachesTo.class);
 
     public Compute(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Compute.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.node;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -68,7 +69,8 @@ public class Compute extends RootNode {
     public static ToscaKey<BindableCapability> BINDING = new ToscaKey<>(CAPABILITIES, "binding")
         .type(BindableCapability.class);
     public static ToscaKey<BlockStorageRequirement> LOCAL_STORAGE = new RequirementKey<>("local_storage")
-        .types(AttachmentCapability.class, BlockStorage.class, AttachesTo.class);
+        .subTypes(AttachmentCapability.class, BlockStorage.class, AttachesTo.class)
+        .type(BlockStorageRequirement.class);
 
     public Compute(MappingEntity mappingEntity) {
         super(mappingEntity);
@@ -118,14 +120,14 @@ public class Compute extends RootNode {
      @return {@link #NETWORKS}
      */
     public Set<NetworkInfo> getNetworks() {
-        return getCollection(NETWORKS);
+        return new HashSet<>(getCollection(NETWORKS));
     }
 
     /**
      @return {@link #PORTS}
      */
     public Set<PortInfo> getPorts() {
-        return getCollection(PORTS);
+        return new HashSet<>(getCollection(PORTS));
     }
 
     /**

--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
@@ -1,9 +1,15 @@
 package org.opentosca.toscana.model.node;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.ContainerCapability;
+import org.opentosca.toscana.model.capability.EndpointCapability;
+import org.opentosca.toscana.model.capability.StorageCapability;
+import org.opentosca.toscana.model.relation.DependsOn;
+import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.ContainerHostRequirement;
 import org.opentosca.toscana.model.requirement.NetworkRequirement;
 import org.opentosca.toscana.model.requirement.StorageRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -18,12 +24,12 @@ import lombok.ToString;
 @ToString
 public class ContainerApplication extends RootNode {
 
-    public static ToscaKey<ContainerHostRequirement> HOST = new ToscaKey<>(REQUIREMENTS, "host")
-        .type(ContainerHostRequirement.class);
-    public static ToscaKey<StorageRequirement> STORAGE = new ToscaKey<>(REQUIREMENTS, "storage")
-        .type(StorageRequirement.class);
-    public static ToscaKey<NetworkRequirement> NETWORK = new ToscaKey<>(REQUIREMENTS, "network")
-        .type(NetworkRequirement.class);
+    public static ToscaKey<ContainerHostRequirement> HOST = new RequirementKey<>("host")
+        .types(ContainerCapability.class, ContainerRuntime.class, HostedOn.class);
+    public static ToscaKey<StorageRequirement> STORAGE = new RequirementKey<>("storage")
+        .types(StorageCapability.class, RootNode.class, DependsOn.class);
+    public static ToscaKey<NetworkRequirement> NETWORK = new RequirementKey<>("network")
+        .types(EndpointCapability.class, RootNode.class, DependsOn.class);
 
     public ContainerApplication(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ContainerApplication.java
@@ -25,11 +25,14 @@ import lombok.ToString;
 public class ContainerApplication extends RootNode {
 
     public static ToscaKey<ContainerHostRequirement> HOST = new RequirementKey<>("host")
-        .types(ContainerCapability.class, ContainerRuntime.class, HostedOn.class);
+        .subTypes(ContainerCapability.class, ContainerRuntime.class, HostedOn.class)
+        .type(ContainerHostRequirement.class);
     public static ToscaKey<StorageRequirement> STORAGE = new RequirementKey<>("storage")
-        .types(StorageCapability.class, RootNode.class, DependsOn.class);
+        .subTypes(StorageCapability.class, RootNode.class, DependsOn.class)
+        .type(StorageRequirement.class);
     public static ToscaKey<NetworkRequirement> NETWORK = new RequirementKey<>("network")
-        .types(EndpointCapability.class, RootNode.class, DependsOn.class);
+        .subTypes(EndpointCapability.class, RootNode.class, DependsOn.class)
+        .type(NetworkRequirement.class);
 
     public ContainerApplication(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/Database.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Database.java
@@ -3,8 +3,11 @@ package org.opentosca.toscana.model.node;
 import java.util.Optional;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
+import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.DbmsRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -48,8 +51,8 @@ public class Database extends RootNode {
     public static ToscaKey<DatabaseEndpointCapability> DATABASE_ENDPOINT = new ToscaKey<>(CAPABILITIES, "database_endpoint")
         .type(DatabaseEndpointCapability.class);
 
-    public static ToscaKey<DbmsRequirement> HOST = new ToscaKey<>(REQUIREMENTS, "host")
-        .type(DbmsRequirement.class);
+    public static ToscaKey<DbmsRequirement> HOST = new RequirementKey<>("host")
+        .types(ContainerCapability.class, Dbms.class, HostedOn.class);
 
     public Database(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/Database.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/Database.java
@@ -27,7 +27,7 @@ public class Database extends RootNode {
      (TOSCA Simple Profile in YAML Version 1.1, p. 173)
      */
     public static ToscaKey<String> DATABASE_NAME = new ToscaKey<>(PROPERTIES, "name")
-        .required(true);
+        .required();
 
     /**
      The optional port the database service will use for incoming data and request.
@@ -52,14 +52,11 @@ public class Database extends RootNode {
         .type(DatabaseEndpointCapability.class);
 
     public static ToscaKey<DbmsRequirement> HOST = new RequirementKey<>("host")
-        .types(ContainerCapability.class, Dbms.class, HostedOn.class);
+        .subTypes(ContainerCapability.class, Dbms.class, HostedOn.class)
+        .type(DbmsRequirement.class);
 
     public Database(MappingEntity mappingEntity) {
         super(mappingEntity);
-        init();
-    }
-
-    private void init() {
         setDefault(DATABASE_ENDPOINT, new DatabaseEndpointCapability(getChildEntity(DATABASE_ENDPOINT)));
         setDefault(HOST, new DbmsRequirement(getChildEntity(HOST)));
     }

--- a/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
@@ -1,8 +1,11 @@
 package org.opentosca.toscana.model.node;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.DockerContainerCapability;
+import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.ContainerHostRequirement;
 import org.opentosca.toscana.model.requirement.DockerHostRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -13,8 +16,8 @@ import lombok.ToString;
 @ToString
 public class DockerApplication extends ContainerApplication {
 
-    public static ToscaKey<DockerHostRequirement> DOCKER_HOST = new ToscaKey<>(REQUIREMENTS, "host")
-        .type(DockerHostRequirement.class);
+    public static ToscaKey<DockerHostRequirement> DOCKER_HOST = new RequirementKey<>("host")
+        .types(DockerContainerCapability.class, ContainerRuntime.class, HostedOn.class);
 
     public DockerApplication(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/DockerApplication.java
@@ -17,7 +17,8 @@ import lombok.ToString;
 public class DockerApplication extends ContainerApplication {
 
     public static ToscaKey<DockerHostRequirement> DOCKER_HOST = new RequirementKey<>("host")
-        .types(DockerContainerCapability.class, ContainerRuntime.class, HostedOn.class);
+        .subTypes(DockerContainerCapability.class, ContainerRuntime.class, HostedOn.class)
+        .type(DockerHostRequirement.class);
 
     public DockerApplication(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
@@ -32,7 +32,8 @@ public class LoadBalancer extends RootNode {
     public static ToscaKey<PublicEndpointCapability> CLIENT = new ToscaKey<>(CAPABILITIES, "client")
         .type(PublicEndpointCapability.class);
     public static ToscaKey<NetworkRequirement> APPLICATION = new RequirementKey<>("application")
-        .types(EndpointCapability.class, RootNode.class, DependsOn.class);
+        .subTypes(EndpointCapability.class, RootNode.class, DependsOn.class)
+        .type(NetworkRequirement.class);
 
     public LoadBalancer(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/LoadBalancer.java
@@ -3,9 +3,12 @@ package org.opentosca.toscana.model.node;
 import java.util.Optional;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.capability.PublicEndpointCapability;
 import org.opentosca.toscana.model.datatype.Range;
+import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.requirement.NetworkRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -28,8 +31,8 @@ public class LoadBalancer extends RootNode {
     public static ToscaKey<String> ALGORITHM = new ToscaKey<>(PROPERTIES, "algorithm");
     public static ToscaKey<PublicEndpointCapability> CLIENT = new ToscaKey<>(CAPABILITIES, "client")
         .type(PublicEndpointCapability.class);
-    public static ToscaKey<NetworkRequirement> APPLICATION = new ToscaKey<>(REQUIREMENTS, "application")
-        .type(NetworkRequirement.class);
+    public static ToscaKey<NetworkRequirement> APPLICATION = new RequirementKey<>("application")
+        .types(EndpointCapability.class, RootNode.class, DependsOn.class);
 
     public LoadBalancer(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
@@ -16,7 +16,9 @@ import lombok.ToString;
 public class MysqlDatabase extends Database {
 
     public static ToscaKey<MysqlDbmsRequirement> HOST = new RequirementKey<>("host")
-        .types(ContainerCapability.class, MysqlDbms.class, HostedOn.class);
+        .subTypes(ContainerCapability.class, MysqlDbms.class, HostedOn.class)
+        .type(MysqlDbmsRequirement.class);
+    
 
     public MysqlDatabase(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/MysqlDatabase.java
@@ -1,7 +1,10 @@
 package org.opentosca.toscana.model.node;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.ContainerCapability;
+import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.MysqlDbmsRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -12,8 +15,8 @@ import lombok.ToString;
 @ToString
 public class MysqlDatabase extends Database {
 
-    public static ToscaKey<MysqlDbmsRequirement> HOST = new ToscaKey<>(REQUIREMENTS, "host")
-        .type(MysqlDbmsRequirement.class);
+    public static ToscaKey<MysqlDbmsRequirement> HOST = new RequirementKey<>("host")
+        .types(ContainerCapability.class, MysqlDbms.class, HostedOn.class);
 
     public MysqlDatabase(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/ObjectStorage.java
@@ -25,7 +25,7 @@ public class ObjectStorage extends RootNode {
      (TOSCA Simple Profile in YAML Version 1.1, p. 174)
      */
     public static ToscaKey<String> STORAGE_NAME = new ToscaKey<>(PROPERTIES, "name")
-        .required(true);
+        .required();
 
     /**
      The optional requested initial storage size in GB.

--- a/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/RootNode.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.node;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
@@ -25,7 +26,7 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
     public static final ToscaKey<String> TYPE = new ToscaKey<>("type");
 
     public static ToscaKey<Requirement> REQUIREMENTS = new ToscaKey<>("requirements")
-        .type(Requirement.class);
+        .type(Requirement.class).list();
     public static ToscaKey<Capability> CAPABILITIES = new ToscaKey<>("capabilities")
         .type(Capability.class);
     public static ToscaKey<Interface> INTERFACES = new ToscaKey<>("interfaces")
@@ -45,14 +46,14 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
      @return {@link #REQUIREMENTS}
      */
     public Set<Requirement> getRequirements() {
-        return getCollection(REQUIREMENTS);
+        return new HashSet<>(getCollection(REQUIREMENTS));
     }
 
     /**
      @return {@link #CAPABILITIES}
      */
     public Set<Capability> getCapabilities() {
-        return getCollection(CAPABILITIES);
+        return new HashSet<>(getCollection(CAPABILITIES));
     }
 
     /**
@@ -74,14 +75,14 @@ public abstract class RootNode extends DescribableEntity implements VisitableNod
      @return {@link #ARTIFACTS}
      */
     public Set<Artifact> getArtifacts() {
-        return getCollection(ARTIFACTS);
+        return new HashSet<>(getCollection(ARTIFACTS));
     }
 
     /**
      @return {@link #INTERFACES}
      */
     public Set<Interface> getInterfaces() {
-        return getCollection(INTERFACES);
+        return new HashSet<>(getCollection(INTERFACES));
     }
 }
 

--- a/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
@@ -36,7 +36,8 @@ public class SoftwareComponent extends RootNode {
         .type(Credential.class);
 
     public static ToscaKey<HostRequirement> HOST = new RequirementKey<>("host")
-        .types(ContainerCapability.class, Compute.class, HostedOn.class);
+        .subTypes(ContainerCapability.class, Compute.class, HostedOn.class)
+        .type(HostRequirement.class);
 
     public SoftwareComponent(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/SoftwareComponent.java
@@ -3,8 +3,11 @@ package org.opentosca.toscana.model.node;
 import java.util.Optional;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.datatype.Credential;
+import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.HostRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -32,8 +35,8 @@ public class SoftwareComponent extends RootNode {
     public static ToscaKey<Credential> ADMIN_CREDENTIAL = new ToscaKey<>(PROPERTIES, "admin_credential")
         .type(Credential.class);
 
-    public static ToscaKey<HostRequirement> HOST = new ToscaKey<>(REQUIREMENTS, "host")
-        .type(HostRequirement.class);
+    public static ToscaKey<HostRequirement> HOST = new RequirementKey<>("host")
+        .types(ContainerCapability.class, Compute.class, HostedOn.class);
 
     public SoftwareComponent(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -4,8 +4,11 @@ import java.util.Optional;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.model.capability.ContainerCapability;
+import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
+import org.opentosca.toscana.model.relation.ConnectsTo;
 import org.opentosca.toscana.model.relation.HostedOn;
+import org.opentosca.toscana.model.requirement.DatabaseEndpointRequirement;
 import org.opentosca.toscana.model.requirement.WebServerRequirement;
 import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
@@ -34,6 +37,11 @@ public class WebApplication extends RootNode {
     public static ToscaKey<WebServerRequirement> HOST = new RequirementKey<>("host")
         .subTypes(ContainerCapability.class, WebServer.class, HostedOn.class)
         .type(WebServerRequirement.class);
+    
+    // TODO this is a hack: implement arbitrary requirement handling and delete this ToscaKey again
+    public static ToscaKey<DatabaseEndpointRequirement> DATABASE_ENDPOINT = new RequirementKey<>("database_endpoint")
+        .subTypes(DatabaseEndpointCapability.class, Database.class, ConnectsTo.class)
+        .type(DatabaseEndpointRequirement.class);
 
     public WebApplication(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -32,7 +32,8 @@ public class WebApplication extends RootNode {
     public static ToscaKey<EndpointCapability> APP_ENDPOINT = new ToscaKey<>(CAPABILITIES, "app_endpoint")
         .type(EndpointCapability.class);
     public static ToscaKey<WebServerRequirement> HOST = new RequirementKey<>("host")
-        .types(ContainerCapability.class, WebServer.class, HostedOn.class);
+        .subTypes(ContainerCapability.class, WebServer.class, HostedOn.class)
+        .type(WebServerRequirement.class);
 
     public WebApplication(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WebApplication.java
@@ -3,8 +3,11 @@ package org.opentosca.toscana.model.node;
 import java.util.Optional;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.ContainerCapability;
 import org.opentosca.toscana.model.capability.EndpointCapability;
+import org.opentosca.toscana.model.relation.HostedOn;
 import org.opentosca.toscana.model.requirement.WebServerRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -28,8 +31,8 @@ public class WebApplication extends RootNode {
 
     public static ToscaKey<EndpointCapability> APP_ENDPOINT = new ToscaKey<>(CAPABILITIES, "app_endpoint")
         .type(EndpointCapability.class);
-    public static ToscaKey<WebServerRequirement> HOST = new ToscaKey<>(REQUIREMENTS, "host")
-        .type(WebServerRequirement.class);
+    public static ToscaKey<WebServerRequirement> HOST = new RequirementKey<>("host")
+        .types(ContainerCapability.class, WebServer.class, HostedOn.class);
 
     public WebApplication(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
@@ -1,7 +1,10 @@
 package org.opentosca.toscana.model.node;
 
 import org.opentosca.toscana.core.parse.model.MappingEntity;
+import org.opentosca.toscana.model.capability.DatabaseEndpointCapability;
+import org.opentosca.toscana.model.relation.ConnectsTo;
 import org.opentosca.toscana.model.requirement.DatabaseEndpointRequirement;
+import org.opentosca.toscana.model.util.RequirementKey;
 import org.opentosca.toscana.model.util.ToscaKey;
 import org.opentosca.toscana.model.visitor.NodeVisitor;
 
@@ -21,8 +24,8 @@ public class WordPress extends WebApplication {
 
     public static ToscaKey<String> DB_HOST = new ToscaKey<>(PROPERTIES, "db_host").required(true);
 
-    public static ToscaKey<DatabaseEndpointRequirement> DATABASE_ENDPOINT = new ToscaKey<>(REQUIREMENTS, "database_endpoint")
-        .type(DatabaseEndpointRequirement.class);
+    public static ToscaKey<DatabaseEndpointRequirement> DATABASE_ENDPOINT = new RequirementKey<>("database_endpoint")
+        .types(DatabaseEndpointCapability.class, Database.class, ConnectsTo.class);
 
     public WordPress(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
+++ b/server/src/main/java/org/opentosca/toscana/model/node/WordPress.java
@@ -18,14 +18,15 @@ import lombok.ToString;
 @ToString
 public class WordPress extends WebApplication {
 
-    public static ToscaKey<String> ADMIN_USER = new ToscaKey<>(PROPERTIES, "admin_user").required(true);
+    public static ToscaKey<String> ADMIN_USER = new ToscaKey<>(PROPERTIES, "admin_user").required();
 
-    public static ToscaKey<String> ADMIN_PASSWORD = new ToscaKey<>(PROPERTIES, "admin_password").required(true);
+    public static ToscaKey<String> ADMIN_PASSWORD = new ToscaKey<>(PROPERTIES, "admin_password").required();
 
-    public static ToscaKey<String> DB_HOST = new ToscaKey<>(PROPERTIES, "db_host").required(true);
+    public static ToscaKey<String> DB_HOST = new ToscaKey<>(PROPERTIES, "db_host").required();
 
     public static ToscaKey<DatabaseEndpointRequirement> DATABASE_ENDPOINT = new RequirementKey<>("database_endpoint")
-        .types(DatabaseEndpointCapability.class, Database.class, ConnectsTo.class);
+        .subTypes(DatabaseEndpointCapability.class, Database.class, ConnectsTo.class)
+        .type(DatabaseEndpointRequirement.class);
 
     public WordPress(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/main/java/org/opentosca/toscana/model/operation/Interface.java
+++ b/server/src/main/java/org/opentosca/toscana/model/operation/Interface.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.operation;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -35,7 +36,7 @@ public class Interface extends BaseToscaElement {
      @return {@link #INPUTS}
      */
     public Set<OperationVariable> getInputs() {
-        return getCollection(INPUTS);
+        return new HashSet<>(getCollection(INPUTS));
     }
 
     /**

--- a/server/src/main/java/org/opentosca/toscana/model/operation/Operation.java
+++ b/server/src/main/java/org/opentosca/toscana/model/operation/Operation.java
@@ -1,5 +1,6 @@
 package org.opentosca.toscana.model.operation;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -67,20 +68,20 @@ public class Operation extends DescribableEntity {
      @return {@link #DEPENDENCIES}
      */
     public Set<String> getDependencies() {
-        return getCollection(DEPENDENCIES);
+        return new HashSet<>(getCollection(DEPENDENCIES));
     }
 
     /**
      @return {@link #INPUTS}
      */
     public Set<OperationVariable> getInputs() {
-        return getCollection(INPUTS);
+        return new HashSet<>(getCollection(INPUTS));
     }
 
     /**
      @return {@link #OUTPUTS}
      */
     public Set<OperationVariable> getOutputs() {
-        return getCollection(OUTPUTS);
+        return new HashSet<>(getCollection(OUTPUTS));
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
+++ b/server/src/main/java/org/opentosca/toscana/model/relation/RootRelationship.java
@@ -14,7 +14,7 @@ import lombok.ToString;
  */
 @EqualsAndHashCode
 @ToString
-public class RootRelationship extends DescribableEntity implements VisitableRelationship {
+public abstract class RootRelationship extends DescribableEntity implements VisitableRelationship {
 
     public RootRelationship(MappingEntity entity) {
         super(entity);

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/DatabaseEndpointRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/DatabaseEndpointRequirement.java
@@ -14,6 +14,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class DatabaseEndpointRequirement extends Requirement<DatabaseEndpointCapability, Database, ConnectsTo> {
+
     public ToscaKey<DatabaseEndpointCapability> CAPABILITY = new ToscaKey<>(CAPABILITY_NAME)
         .type(DatabaseEndpointCapability.class);
     public ToscaKey<Database> NODE = new ToscaKey<>(NODE_NAME)

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/NetworkRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/NetworkRequirement.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.model.capability.EndpointCapability;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.util.ToscaKey;
 
@@ -13,14 +14,14 @@ import lombok.ToString;
 
 @EqualsAndHashCode
 @ToString
-public class NetworkRequirement extends Requirement<EndpointCapability, RootNode, RootRelationship> {
+public class NetworkRequirement extends Requirement<EndpointCapability, RootNode, DependsOn> {
 
     public ToscaKey<EndpointCapability> CAPABILITY = new ToscaKey<>(CAPABILITY_NAME)
         .type(EndpointCapability.class);
 
     public NetworkRequirement(MappingEntity mappingEntity) {
         super(mappingEntity);
-        setDefault(RELATIONSHIP, new RootRelationship(getChildEntity(RELATIONSHIP)));
+        setDefault(RELATIONSHIP, new DependsOn(getChildEntity(RELATIONSHIP)));
     }
 
     /**

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
@@ -8,6 +8,7 @@ import org.opentosca.toscana.model.BaseToscaElement;
 import org.opentosca.toscana.model.capability.Capability;
 import org.opentosca.toscana.model.datatype.Range;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.util.ToscaKey;
 
@@ -68,7 +69,7 @@ public class Requirement<CapabilityT extends Capability, NodeT extends RootNode,
 
     public Requirement(MappingEntity mappingEntity) {
         super(mappingEntity);
-        setDefault(RELATIONSHIP, new RootRelationship(getChildEntity(RELATIONSHIP)));
+        setDefault(RELATIONSHIP, new DependsOn(getChildEntity(RELATIONSHIP)));
     }
 
     public Range getOccurrence() {

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/Requirement.java
@@ -29,11 +29,13 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class Requirement<CapabilityT extends Capability, NodeT extends RootNode, RelationshipT extends RootRelationship> extends BaseToscaElement {
+    
 
     public static String CAPABILITY_NAME = "capability";
     public static String NODE_NAME = "node";
     public static String RELATIONSHIP_NAME = "relationship";
 
+    public RequirementType REQUIREMENT_TYPE = new RequirementType(Requirement.class, Capability.class, RootNode.class, RootRelationship.class);
     public ToscaKey<Capability> CAPABILITY = new ToscaKey<>(CAPABILITY_NAME)
         .type(Capability.class);
     public ToscaKey<? extends RootNode> NODE = new ToscaKey<>(NODE_NAME)
@@ -102,5 +104,19 @@ public class Requirement<CapabilityT extends Capability, NodeT extends RootNode,
     public Requirement setRelationship(RelationshipT relationship) {
         set(RELATIONSHIP, relationship);
         return this;
+    }
+    
+    public static class RequirementType {
+        public final Class<? extends Requirement> WRAPPER_TYPE;
+        public final Class<? extends Capability> CAPABILITY_TYPE;
+        public final Class<? extends RootNode> NODE_TYPE;
+        public final Class<? extends RootRelationship> RELATIONSHIP_TYPE;
+
+        public RequirementType(Class<? extends Requirement> wrapper, Class<? extends Capability> capability, Class<? extends RootNode> node, Class<? extends RootRelationship> relationship) {
+            this.WRAPPER_TYPE = wrapper;
+            this.CAPABILITY_TYPE = capability;
+            this.NODE_TYPE = node;
+            this.RELATIONSHIP_TYPE = relationship;
+        }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/requirement/StorageRequirement.java
+++ b/server/src/main/java/org/opentosca/toscana/model/requirement/StorageRequirement.java
@@ -3,6 +3,7 @@ package org.opentosca.toscana.model.requirement;
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.model.capability.StorageCapability;
 import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.relation.DependsOn;
 import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.util.ToscaKey;
 
@@ -11,13 +12,13 @@ import lombok.ToString;
 
 @EqualsAndHashCode
 @ToString
-public class StorageRequirement extends Requirement<StorageCapability, RootNode, RootRelationship> {
+public class StorageRequirement extends Requirement<StorageCapability, RootNode, DependsOn> {
     public ToscaKey<StorageCapability> CAPABILITY = new ToscaKey<>(CAPABILITY_NAME)
         .type(StorageCapability.class);
 
     public StorageRequirement(MappingEntity mappingEntity) {
         super(mappingEntity);
-        setDefault(RELATIONSHIP, new RootRelationship(getChildEntity(RELATIONSHIP)));
+        setDefault(RELATIONSHIP, new DependsOn(getChildEntity(RELATIONSHIP)));
     }
 
     /**

--- a/server/src/main/java/org/opentosca/toscana/model/util/RequirementKey.java
+++ b/server/src/main/java/org/opentosca/toscana/model/util/RequirementKey.java
@@ -1,0 +1,35 @@
+package org.opentosca.toscana.model.util;
+
+import org.opentosca.toscana.model.capability.Capability;
+import org.opentosca.toscana.model.node.RootNode;
+import org.opentosca.toscana.model.relation.RootRelationship;
+import org.opentosca.toscana.model.requirement.Requirement;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RequirementKey<T> extends ToscaKey<T> {
+
+    private final static Logger logger = LoggerFactory.getLogger(RequirementKey.class.getName());
+
+    public final static String FULFILLER = "fulfiller_type";
+    public final static String CAPABILITY = "capability_type";
+    public final static String RELATIONSHIP = "relationship_type";
+
+    public RequirementKey(String name) {
+        super(RootNode.REQUIREMENTS, name);
+        super.type(Requirement.class);
+    }
+
+    public <T> RequirementKey<T> types(Class<? extends Capability> capabilityType, Class<? extends RootNode> fulfillerType, Class<? extends RootRelationship> relationshipType) {
+        directive(FULFILLER, fulfillerType);
+        directive(CAPABILITY, capabilityType);
+        directive(RELATIONSHIP, relationshipType);
+        return (RequirementKey<T>) this;
+    }
+
+    @Override
+    public <T1> ToscaKey<T1> type(Class type) {
+        throw new UnsupportedOperationException("use types() instead");
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/model/util/RequirementKey.java
+++ b/server/src/main/java/org/opentosca/toscana/model/util/RequirementKey.java
@@ -5,12 +5,7 @@ import org.opentosca.toscana.model.node.RootNode;
 import org.opentosca.toscana.model.relation.RootRelationship;
 import org.opentosca.toscana.model.requirement.Requirement;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class RequirementKey<T> extends ToscaKey<T> {
-
-    private final static Logger logger = LoggerFactory.getLogger(RequirementKey.class.getName());
 
     public final static String FULFILLER = "fulfiller_type";
     public final static String CAPABILITY = "capability_type";
@@ -21,15 +16,10 @@ public class RequirementKey<T> extends ToscaKey<T> {
         super.type(Requirement.class);
     }
 
-    public <T> RequirementKey<T> types(Class<? extends Capability> capabilityType, Class<? extends RootNode> fulfillerType, Class<? extends RootRelationship> relationshipType) {
+    public <T> RequirementKey<T> subTypes(Class<? extends Capability> capabilityType, Class<? extends RootNode> fulfillerType, Class<? extends RootRelationship> relationshipType) {
         directive(FULFILLER, fulfillerType);
         directive(CAPABILITY, capabilityType);
         directive(RELATIONSHIP, relationshipType);
         return (RequirementKey<T>) this;
-    }
-
-    @Override
-    public <T1> ToscaKey<T1> type(Class type) {
-        throw new UnsupportedOperationException("use types() instead");
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/util/ToscaKey.java
+++ b/server/src/main/java/org/opentosca/toscana/model/util/ToscaKey.java
@@ -18,18 +18,19 @@ public class ToscaKey<T> {
      Directives can be used in order to enrich the semantics of the key (e.g., used to specify unit sizes)
      */
     private final Map<String, Object> directives = new HashMap<>();
-    private ToscaKey<?> predecessor;
-    private boolean required;
-    private Class type;
+    private ToscaKey<?> predecessor = null;
+    private boolean required = false;
+    /**
+     True if this key denotes a list entity.
+     */
+    private boolean isList = false;
+    private Class type = String.class;
 
     /**
      Creates a ToscaKey which is not mandatory and of type String
      */
     public ToscaKey(String name) {
         this.name = name;
-        this.type = String.class;
-        this.required = false;
-        this.predecessor = null;
     }
 
     /**
@@ -40,8 +41,13 @@ public class ToscaKey<T> {
         this.predecessor = predecessor;
     }
 
-    public <T> ToscaKey<T> required(boolean required) {
-        this.required = required;
+    public <T> ToscaKey<T> required() {
+        this.required = true;
+        return (ToscaKey<T>) this;
+    }
+
+    public <T> ToscaKey<T> list() {
+        this.isList = true;
         return (ToscaKey<T>) this;
     }
 
@@ -73,6 +79,14 @@ public class ToscaKey<T> {
 
     public Map<String, Object> getDirectives() {
         return directives;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public boolean isList() {
+        return isList;
     }
 
     public boolean hasSameShape(ToscaKey<?> other) {

--- a/server/src/test/java/org/opentosca/toscana/core/parse/converter/NodeTypeResolverTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/converter/NodeTypeResolverTest.java
@@ -7,13 +7,12 @@ import java.util.stream.Collectors;
 
 import org.opentosca.toscana.core.BaseUnitTest;
 import org.opentosca.toscana.core.parse.converter.util.NodeTypeResolver;
+import org.opentosca.toscana.core.parse.converter.util.ToscaStructure;
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.core.parse.model.ScalarEntity;
 import org.opentosca.toscana.core.parse.model.ServiceGraph;
-import org.opentosca.toscana.model.EntityId;
 import org.opentosca.toscana.model.node.RootNode;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.eclipse.winery.yaml.common.Defaults;
 import org.junit.Test;
@@ -36,7 +35,7 @@ public class NodeTypeResolverTest extends BaseUnitTest {
         for (String nodeType : wineryNodeTypes) {
             logger.info("Testing conversion of type '{}'", nodeType);
             ServiceGraph graph = new ServiceGraph(log);
-            MappingEntity nodeEntity = new MappingEntity(new EntityId(Lists.newArrayList("my", "id")), graph);
+            MappingEntity nodeEntity = new MappingEntity(ToscaStructure.NODE_TEMPLATES.descend("my-node"), graph);
             graph.addEntity(nodeEntity);
             ScalarEntity typeEntity = new ScalarEntity(nodeType, nodeEntity.getId().descend("type"), graph);
             graph.addEntity(typeEntity);

--- a/server/src/test/resources/csars/yaml/valid/lamp-input/template.yaml
+++ b/server/src/test/resources/csars/yaml/valid/lamp-input/template.yaml
@@ -30,7 +30,10 @@ topology_template:
       type: tosca.nodes.WebApplication
       requirements:
         - host: apache_web_server
-        - database_endpoint: my_db
+        - database_endpoint: 
+            node: my_db
+            capability: database_endpoint
+            relationship: ConnectsTo
       interfaces:
         Standard:
           create:


### PR DESCRIPTION
Currently, relationships are always of type RootRelationship when obtained from the EffectiveModel.
This PR will fix this: Afterwards, obtained Relationship will be of their actual Subtype.