### PR TITLE
Cleanup test data

### DIFF
--- a/server/src/integration/java/org/opentosca/toscana/plugins/BaseTransformTest.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/BaseTransformTest.java
@@ -98,7 +98,7 @@ public abstract class BaseTransformTest extends BaseIntegrationTest {
      initializes the transformation context
      */
     protected TransformationContext initContext() throws Exception {
-        return new TransformationContext(contentDir, workingDir, log, model, getProperties());
+        return new TransformationContext(contentDir, workingDir, logMock(), model, getProperties());
     }
 
     /**

--- a/server/src/integration/java/org/opentosca/toscana/plugins/cloudformation/CloudFormationLampIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/cloudformation/CloudFormationLampIT.java
@@ -22,7 +22,7 @@ public class CloudFormationLampIT extends BaseTransformTest {
 
     @Override
     protected EffectiveModel getModel() {
-        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, log);
+        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, logMock());
     }
 
     @Override

--- a/server/src/integration/java/org/opentosca/toscana/plugins/cloudfoundry/CloudFoundryLampIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/cloudfoundry/CloudFoundryLampIT.java
@@ -43,7 +43,7 @@ public class CloudFoundryLampIT extends BaseTransformTest {
 
     @Override
     protected EffectiveModel getModel() throws Exception {
-        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, log);
+        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, logMock());
     }
 
     @Override

--- a/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampIT.java
@@ -29,7 +29,7 @@ public class KubernetesLampIT extends BaseTransformTest {
 
     @Override
     protected EffectiveModel getModel() {
-        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, log);
+        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, logMock());
     }
 
     @Override

--- a/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampMultiNodeIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/KubernetesLampMultiNodeIT.java
@@ -16,7 +16,7 @@ public class KubernetesLampMultiNodeIT extends KubernetesLampIT {
 
     @Override
     protected EffectiveModel getModel() {
-        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_MULTI_COMPUTE_TEMPLATE, log);
+        return new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_MULTI_COMPUTE_TEMPLATE, logMock());
     }
 
     @Override

--- a/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTagLoaderIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTagLoaderIT.java
@@ -1,7 +1,6 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.opentosca.toscana.IntegrationTest;
 import org.opentosca.toscana.core.BaseTest;
@@ -9,8 +8,6 @@ import org.opentosca.toscana.core.CoreConfiguration;
 import org.opentosca.toscana.core.Main;
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.core.parse.model.ServiceGraph;
-import org.opentosca.toscana.core.transformation.logging.Log;
-import org.opentosca.toscana.core.transformation.logging.LogImpl;
 import org.opentosca.toscana.core.util.Preferences;
 import org.opentosca.toscana.model.EntityId;
 import org.opentosca.toscana.model.capability.OsCapability;
@@ -50,19 +47,14 @@ public class MapperTagLoaderIT extends BaseTest {
     static final String LOADER_TEST_PROFILE = "base-image-mapper-loader-test";
     private static final Logger logger = LoggerFactory.getLogger(MapperTagLoaderIT.class);
     private static EntityId entityId = new EntityId(Lists.newArrayList("my", "id"));
-    private static File logFile;
-    private static Log log;
     private static MappingEntity entity;
 
     @Autowired
     private BaseImageMapper mapper;
 
     @BeforeClass
-    public static void setUp() throws IOException {
-        logFile = File.createTempFile("testlog", "log", PROJECT_ROOT);
-        logFile.deleteOnExit();
-        log = new LogImpl(logFile);
-        entity = new MappingEntity(entityId, new ServiceGraph(log));
+    public static void setUp() {
+        entity = new MappingEntity(entityId, new ServiceGraph(logMock()));
     }
 
     @Test

--- a/server/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
+++ b/server/src/main/java/org/opentosca/toscana/core/transformation/TransformationImpl.java
@@ -35,11 +35,11 @@ public class TransformationImpl implements Transformation {
         this.targetPlatform = targetPlatform;
         this.log = log;
         this.model = model;
-        // caution: side effect
-        // transformationState can get set to INPUT_REQUIRED by this call
         Set<Property> properties = new HashSet<>();
         properties.addAll(model.getInputs().values());
         properties.addAll(targetPlatform.getProperties());
+        // caution: side effect
+        // transformationState can get set to INPUT_REQUIRED by this call
         this.properties = new PropertyInstance(properties, this);
     }
 

--- a/server/src/test/java/org/opentosca/toscana/api/TransformationControllerTest.java
+++ b/server/src/test/java/org/opentosca/toscana/api/TransformationControllerTest.java
@@ -176,7 +176,7 @@ public class TransformationControllerTest extends BaseSpringTest {
         List<Csar> csars = new ArrayList<>();
         when(csarService.getCsar(anyString())).thenReturn(Optional.empty());
         for (String name : CSAR_NAMES) {
-            Csar csar = new CsarImpl(TestCsars.VALID_EMPTY_TOPOLOGY_TEMPLATE, name, log);
+            Csar csar = new CsarImpl(TestCsars.VALID_EMPTY_TOPOLOGY_TEMPLATE, name, logMock());
             when(csarService.getCsar(name)).thenReturn(Optional.of(csar));
         }
         when(csarService.getCsars()).thenReturn(csars);

--- a/server/src/test/java/org/opentosca/toscana/core/BaseTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/BaseTest.java
@@ -10,10 +10,8 @@ import org.opentosca.toscana.model.EffectiveModel;
 import org.opentosca.toscana.model.relation.RootRelationship;
 
 import org.jgrapht.graph.DefaultDirectedGraph;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.Timeout;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.slf4j.LoggerFactory;
@@ -30,15 +28,17 @@ public abstract class BaseTest {
 
     // "user.dir" is module root
     protected static final File PROJECT_ROOT = new File(System.getProperty("user.dir"));
-    protected static Log log;
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
-    
-    @BeforeClass
-    public static void setupLog() {
-        log = mock(Log.class);
+
+    /**
+     @return a mocked Log instance which returns a normal logger upon any getLogger call
+     */
+    public static Log logMock() {
+        Log log = mock(Log.class);
         when(log.getLogger(anyString())).thenReturn(LoggerFactory.getLogger("test logger"));
         when(log.getLogger(any(Class.class))).thenReturn(LoggerFactory.getLogger("test logger"));
+        return log;
     }
 
     /**

--- a/server/src/test/java/org/opentosca/toscana/core/parse/converter/GraphNormalizerTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/converter/GraphNormalizerTest.java
@@ -31,7 +31,7 @@ public class GraphNormalizerTest extends BaseUnitTest {
 
     @Test
     public void repositoryNormalization() {
-        ServiceGraph graph = new ServiceGraph(REPOSITORY, log);
+        ServiceGraph graph = new ServiceGraph(REPOSITORY, logMock());
         Collection<Entity> repositories = graph.getEntity(ToscaStructure.REPOSITORIES).get().getChildren();
         Entity repository = repositories.iterator().next();
         Optional<Entity> url = repository.getChild("url");
@@ -41,7 +41,7 @@ public class GraphNormalizerTest extends BaseUnitTest {
 
     @Test
     public void operationNormalization() {
-        ServiceGraph graph = new ServiceGraph(OPERATION, log);
+        ServiceGraph graph = new ServiceGraph(OPERATION, logMock());
         EntityId lifecycleId = ToscaStructure.NODE_TEMPLATES.descend("test-node")
             .descend(RootNode.INTERFACES.name)
             .descend(RootNode.STANDARD_LIFECYCLE.name);

--- a/server/src/test/java/org/opentosca/toscana/core/parse/converter/IntrinsicFunctionResolverTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/converter/IntrinsicFunctionResolverTest.java
@@ -21,28 +21,28 @@ public class IntrinsicFunctionResolverTest extends BaseUnitTest {
 
     @Test
     public void getInputTest() {
-        EffectiveModel model = new EffectiveModelFactory().create(GET_INPUT, log);
+        EffectiveModel model = new EffectiveModelFactory().create(GET_INPUT, logMock());
         Database database = (Database) model.getNodeMap().get("my_db");
         assertEquals("my_db_name", database.getDatabaseName());
     }
 
     @Test
     public void getPropertyTest() {
-        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY, log);
+        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY, logMock());
         Database database = (Database) model.getNodeMap().get("my_second_db");
         assertEquals("my_db_name", database.getDatabaseName());
     }
 
     @Test
     public void getPropertySelfTest() {
-        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY_SELF, log);
+        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY_SELF, logMock());
         Database database = (Database) model.getNodeMap().get("my_db");
         assertEquals("my_user_name", database.getDatabaseName());
     }
 
     @Test
     public void getNestedPropertyTest() {
-        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY_IN_INTERFACE, log);
+        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY_IN_INTERFACE, logMock());
         Database database = (Database) model.getNodeMap().get("my_db");
         Set<OperationVariable> inputs = database.getStandardLifecycle().getConfigure().get().getInputs();
         OperationVariable input = inputs.stream().findFirst().orElse(null);
@@ -54,7 +54,7 @@ public class IntrinsicFunctionResolverTest extends BaseUnitTest {
      */
     @Test
     public void correctPropertyNameTest() {
-        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY_IN_INPUT, log);
+        EffectiveModel model = new EffectiveModelFactory().create(GET_PROPERTY_IN_INPUT, logMock());
         Database myApp = (Database) model.getNodeMap().get("my_db");
         OperationVariable input = myApp.getStandardLifecycle().getConfigure().get().getInputs().iterator().next();
         assertEquals("correct-name", input.getKey());

--- a/server/src/test/java/org/opentosca/toscana/core/parse/converter/LinkResolverTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/converter/LinkResolverTest.java
@@ -26,7 +26,7 @@ public class LinkResolverTest extends BaseUnitTest {
 
     @Test
     public void resolveRequirementLink() {
-        EffectiveModel model = new EffectiveModelFactory().create(REQUIREMENT, log);
+        EffectiveModel model = new EffectiveModelFactory().create(REQUIREMENT, logMock());
         WebServer node = (WebServer) model.getNodeMap().get("test-node1");
         HostRequirement requirement = node.getHost();
         assertNotNull(requirement);
@@ -38,7 +38,7 @@ public class LinkResolverTest extends BaseUnitTest {
 
     @Test
     public void resolveRepositoryLink() {
-        EffectiveModel model = new EffectiveModelFactory().create(REPOSITORY, log);
+        EffectiveModel model = new EffectiveModelFactory().create(REPOSITORY, logMock());
         WebServer node = (WebServer) model.getNodeMap().get("test-node");
         Set<Artifact> artifacts = node.getArtifacts();
         Artifact artifact = artifacts.iterator().next();
@@ -50,7 +50,7 @@ public class LinkResolverTest extends BaseUnitTest {
 
     @Test
     public void resolveImplementationLink() {
-        EffectiveModel model = new EffectiveModelFactory().create(ARTIFACT, log);
+        EffectiveModel model = new EffectiveModelFactory().create(ARTIFACT, logMock());
         WebServer node = (WebServer) model.getNodeMap().get("test-node");
         Optional<Operation> create = node.getStandardLifecycle().getCreate();
         assertTrue(create.isPresent());

--- a/server/src/test/java/org/opentosca/toscana/core/parse/converter/NodeTypeResolverTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/converter/NodeTypeResolverTest.java
@@ -34,7 +34,7 @@ public class NodeTypeResolverTest extends BaseUnitTest {
         Set<String> wineryNodeTypes = getWineryNodeTypes();
         for (String nodeType : wineryNodeTypes) {
             logger.info("Testing conversion of type '{}'", nodeType);
-            ServiceGraph graph = new ServiceGraph(log);
+            ServiceGraph graph = new ServiceGraph(logMock());
             MappingEntity nodeEntity = new MappingEntity(ToscaStructure.NODE_TEMPLATES.descend("my-node"), graph);
             graph.addEntity(nodeEntity);
             ScalarEntity typeEntity = new ScalarEntity(nodeType, nodeEntity.getId().descend("type"), graph);

--- a/server/src/test/java/org/opentosca/toscana/core/parse/model/EffectiveModelInputTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/model/EffectiveModelInputTest.java
@@ -18,7 +18,7 @@ public class EffectiveModelInputTest extends BaseUnitTest {
 
     @Test
     public void inputTest() {
-        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_INPUTS_TEMPLATE, log);
+        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_INPUTS_TEMPLATE, logMock());
         Map<String, Property> inputs = model.getInputs();
         assertNotNull(inputs);
         assertEquals(4, inputs.size());

--- a/server/src/test/java/org/opentosca/toscana/core/parse/model/NodeConverterSoftwareComponentTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/model/NodeConverterSoftwareComponentTest.java
@@ -15,7 +15,7 @@ public class NodeConverterSoftwareComponentTest extends BaseUnitTest {
 
     @Test
     public void softwareComponent() {
-        EffectiveModel model = new EffectiveModelFactory().create(SOFTWARE_COMPONENT, log);
+        EffectiveModel model = new EffectiveModelFactory().create(SOFTWARE_COMPONENT, logMock());
         SoftwareComponent softwareComponent = (SoftwareComponent) model.getNodes().iterator().next();
         Credential credential = softwareComponent.getAdminCredential().get();
         assertEquals("securePassword", credential.getToken());

--- a/server/src/test/java/org/opentosca/toscana/core/parse/model/ServiceGraphTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/model/ServiceGraphTest.java
@@ -161,7 +161,7 @@ public class ServiceGraphTest extends BaseUnitTest {
     private ServiceGraph getGraph() {
         ServiceGraph graph = graphMap.get(currentFile);
         if (graph == null) {
-            graph = new ServiceGraph(currentFile, log);
+            graph = new ServiceGraph(currentFile, logMock());
             graphMap.put(currentFile, graph);
         }
         return graph;

--- a/server/src/test/java/org/opentosca/toscana/core/parse/model/TemplateConverterTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/model/TemplateConverterTest.java
@@ -15,7 +15,7 @@ public class TemplateConverterTest extends BaseUnitTest {
 
     @Test
     public void dockerConverter() {
-        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_MINIMAL_DOCKER_TEMPLATE, log);
+        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_MINIMAL_DOCKER_TEMPLATE, logMock());
         assertNotNull(model);
         DockerApplication dockerApp = (DockerApplication) model.getNodeMap().get("simpleTaskApp");
         DockerHostRequirement host = dockerApp.getDockerHost();
@@ -24,13 +24,13 @@ public class TemplateConverterTest extends BaseUnitTest {
 
     @Test
     public void lampNoInputConverter() {
-        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, log);
+        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, logMock());
         assertNotNull(model);
     }
 
     @Test
     public void lampInputConverter() {
-        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_INPUT_TEMPLATE, log);
+        EffectiveModel model = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_INPUT_TEMPLATE, logMock());
         assertNotNull(model);
     }
 }

--- a/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationDaoUnitTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationDaoUnitTest.java
@@ -42,7 +42,7 @@ public class TransformationDaoUnitTest extends BaseUnitTest {
     public void setUp() throws IOException, InvalidCsarException {
         when(platformService.findPlatformById(PLATFORM1.id)).thenReturn(Optional.ofNullable(PLATFORM1));
         when(preferences.getDataDir()).thenReturn(tmpdir);
-        csar = new CsarImpl(new File(""), "csarIdentifier", log);
+        csar = new CsarImpl(new File(""), "csarIdentifier", logMock());
         File csarTransformationDir = new File(tmpdir, "transformationDir");
         csarTransformationDir.mkdir();
         when(csarDao.getTransformationsDir(csar)).thenReturn(csarTransformationDir);

--- a/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDaoTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDaoTest.java
@@ -47,13 +47,13 @@ public class TransformationFilesystemDaoTest extends BaseUnitTest {
 
     @Before
     public void setUp() throws InvalidCsarException {
-        csar = new CsarImpl(new File(""), "csar1", log);
+        csar = new CsarImpl(new File(""), "csar1", logMock());
         EffectiveModelFactory modelFactory = mock(EffectiveModelFactory.class);
         EffectiveModel model = modelMock();
         when(modelFactory.create(any(Csar.class))).thenReturn(model);
         transformationDao = new TransformationFilesystemDao(platformService, modelFactory);
         transformationDao.setCsarDao(csarDao);
-        transformation = new TransformationImpl(csar, PLATFORM1, log, modelMock());
+        transformation = new TransformationImpl(csar, PLATFORM1, logMock(), modelMock());
         transformationRootDir = transformationDao.getRootDir(transformation);
     }
 
@@ -140,7 +140,7 @@ public class TransformationFilesystemDaoTest extends BaseUnitTest {
     @Test
     public void readTransformationFromDiskWithIllegalPlatform() {
         when(csarDao.getTransformationsDir(csar)).thenReturn(tmpdir);
-        Transformation t = new TransformationImpl(csar, PLATFORM_NOT_SUPPORTED, log, modelMock());
+        Transformation t = new TransformationImpl(csar, PLATFORM_NOT_SUPPORTED, logMock(), modelMock());
         createRandomFiles(transformationDao.getRootDir(t));
 
         assertFalse(transformationDao.find(csar, PLATFORM_NOT_SUPPORTED).isPresent());

--- a/server/src/test/java/org/opentosca/toscana/model/EffectiveModelTest.java
+++ b/server/src/test/java/org/opentosca/toscana/model/EffectiveModelTest.java
@@ -21,7 +21,7 @@ public class EffectiveModelTest extends BaseUnitTest {
      */
     @Test
     public void setPropertyTest() {
-        EffectiveModel model = new EffectiveModel(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, log);
+        EffectiveModel model = new EffectiveModel(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, logMock());
         Compute compute = (Compute) model.getNodes().iterator().next();
         String expected = "test-public-address";
         compute.setPublicAddress(expected);
@@ -32,7 +32,7 @@ public class EffectiveModelTest extends BaseUnitTest {
 
     @Test
     public void setEnumTest() {
-        EffectiveModel model = new EffectiveModel(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, log);
+        EffectiveModel model = new EffectiveModel(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, logMock());
         Compute compute = (Compute) model.getNodes().iterator().next();
         OsCapability os = compute.getOs();
         OsCapability.Distribution expected = OsCapability.Distribution.FEDORA;
@@ -48,7 +48,7 @@ public class EffectiveModelTest extends BaseUnitTest {
      */
     @Test
     public void setDefaultTest() {
-        EffectiveModel model = new EffectiveModel(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, log);
+        EffectiveModel model = new EffectiveModel(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, logMock());
         Compute compute = (Compute) model.getNodes().iterator().next();
         ScalableCapability scalable = compute.getScalable();
         assertNotNull(scalable);

--- a/server/src/test/java/org/opentosca/toscana/plugins/cloudformation/CloudFormationLifecycleTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/cloudformation/CloudFormationLifecycleTest.java
@@ -30,7 +30,7 @@ public class CloudFormationLifecycleTest extends BaseUnitTest {
     @Before
     public void setUp() throws Exception {
         PluginFileAccess access = new PluginFileAccess(new File(""), tmpdir, mock(Log.class));
-        EffectiveModel effectiveModel = new EffectiveModelFactory().create(TestCsars.VALID_MINIMAL_DOCKER_TEMPLATE, log);
+        EffectiveModel effectiveModel = new EffectiveModelFactory().create(TestCsars.VALID_MINIMAL_DOCKER_TEMPLATE, logMock());
 
         when(context.getPluginFileAccess()).thenReturn(access);
         when(context.getLogger((Class<?>) any(Class.class))).thenReturn(LoggerFactory.getLogger("Dummy Logger"));

--- a/server/src/test/java/org/opentosca/toscana/plugins/cloudformation/CloudFormationPluginTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/cloudformation/CloudFormationPluginTest.java
@@ -37,8 +37,8 @@ public class CloudFormationPluginTest extends BaseUnitTest {
 
     @Before
     public void setUp() throws Exception {
-        lamp = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, log);
-        fileAccess = new PluginFileAccess(new File("src/test/resources/csars/yaml/valid/lamp-input/"), tmpdir, log);
+        lamp = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, logMock());
+        fileAccess = new PluginFileAccess(new File("src/test/resources/csars/yaml/valid/lamp-input/"), tmpdir, logMock());
         cfnModule = new CloudFormationModule(fileAccess, "us-west-2", new BasicAWSCredentials("", ""));
         CloudFormationNodeVisitor cfnNodeVisitorL = new CloudFormationNodeVisitor(logger, cfnModule);
         cfnNodeVisitor = spy(cfnNodeVisitorL);

--- a/server/src/test/java/org/opentosca/toscana/plugins/cloudfoundry/CloudFoundryPluginTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/cloudfoundry/CloudFoundryPluginTest.java
@@ -39,12 +39,12 @@ public class CloudFoundryPluginTest extends BaseUnitTest {
     public void setUp() throws Exception {
         Application myApp = new Application(appName, 1);
         NodeVisitor visitor = new NodeVisitor(myApp);
-        EffectiveModel lamp = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, log);
+        EffectiveModel lamp = new EffectiveModelFactory().create(TestCsars.VALID_LAMP_NO_INPUT_TEMPLATE, logMock());
         File sourceDir = new File(resourcesPath, "csars/yaml/valid/lamp-noinput");
         targetDir = new File(tmpdir, "targetDir");
         sourceDir.mkdir();
         targetDir.mkdir();
-        PluginFileAccess fileAccess = new PluginFileAccess(sourceDir, targetDir, log);
+        PluginFileAccess fileAccess = new PluginFileAccess(sourceDir, targetDir, logMock());
         Set<RootNode> nodes = lamp.getNodes();
 
         paths.add("app1/my_app/myphpapp.php");

--- a/server/src/test/java/org/opentosca/toscana/plugins/cloudfoundry/ServiceTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/cloudfoundry/ServiceTest.java
@@ -67,7 +67,7 @@ public class ServiceTest extends BaseUnitTest {
         targetDir = new File(tmpdir, "targetDir");
         sourceDir.mkdir();
         targetDir.mkdir();
-        fileAccess = new PluginFileAccess(sourceDir, targetDir, log);
+        fileAccess = new PluginFileAccess(sourceDir, targetDir, logMock());
     }
 
     @Test

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/KubernetesPluginTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/KubernetesPluginTest.java
@@ -34,7 +34,7 @@ public class KubernetesPluginTest extends BaseUnitTest {
 
     @Test(expected = ValidationFailureException.class)
     public void modelCheckTest() throws Exception {
-        EffectiveModel singleComputeModel = new EffectiveModelFactory().create(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, log);
+        EffectiveModel singleComputeModel = new EffectiveModelFactory().create(TestCsars.VALID_SINGLE_COMPUTE_WINDOWS_TEMPLATE, logMock());
         TransformationContext context = setUpMockTransformationContext(singleComputeModel);
         plugin.transform(context);
     }

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreatorTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/ResourceFileCreatorTest.java
@@ -22,7 +22,7 @@ public class ResourceFileCreatorTest extends BaseUnitTest {
 
     @Test
     public void testReplicationControllerCreation() {
-        ResourceFileCreator resourceFileCreator = new ResourceFileCreator(Pod.getPods(TestNodeStacks.getLampNodeStacks(log)));
+        ResourceFileCreator resourceFileCreator = new ResourceFileCreator(Pod.getPods(TestNodeStacks.getLampNodeStacks(logMock())));
 
         HashMap<String, String> result = null;
         try {

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/BaseDockerfileTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/BaseDockerfileTest.java
@@ -46,7 +46,7 @@ public abstract class BaseDockerfileTest extends BaseUnitTest {
         inputDir.mkdirs();
         workDir.mkdirs();
 
-        access = new PluginFileAccess(inputDir, workDir, log);
+        access = new PluginFileAccess(inputDir, workDir, logMock());
         builder = new DockerfileBuilder("library/ubuntu:latest", WORKING_DIR_SUBFOLDER_NAME, access);
     }
 

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperTest.java
@@ -1,16 +1,15 @@
 package org.opentosca.toscana.plugins.kubernetes.docker.mapper;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.opentosca.toscana.core.BaseTest;
 import org.opentosca.toscana.core.BaseUnitTest;
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.core.parse.model.ServiceGraph;
-import org.opentosca.toscana.core.transformation.logging.LogImpl;
 import org.opentosca.toscana.core.util.Preferences;
 import org.opentosca.toscana.model.EntityId;
 import org.opentosca.toscana.model.capability.OsCapability;
@@ -133,10 +132,8 @@ public class MapperTest extends BaseUnitTest {
         );
     }
 
-    public static MappingEntity getEntity() throws IOException {
-        File logFile = File.createTempFile("testlog", "log", PROJECT_ROOT);
-        logFile.deleteOnExit();
-        ServiceGraph graph = new ServiceGraph(new LogImpl(logFile));
+    public static MappingEntity getEntity() {
+        ServiceGraph graph = new ServiceGraph(BaseTest.logMock());
         MappingEntity entity = new MappingEntity(entityId, graph);
         graph.addEntity(entity);
         return entity;

--- a/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperUtilsTest.java
+++ b/server/src/test/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/MapperUtilsTest.java
@@ -22,7 +22,7 @@ public class MapperUtilsTest extends BaseUnitTest {
 
     @Before
     public void setUp() {
-        ServiceGraph graph = new ServiceGraph(log);
+        ServiceGraph graph = new ServiceGraph(logMock());
         entity = new MappingEntity(entityId, graph);
         graph.addEntity(entity);
     }


### PR DESCRIPTION
I was bothered by the dozens of testlog files created by our testsuite while running.

After this patch is applied, all Log instances in tests are mocked and therefore do not create log files.