### PR TITLE
Testsuite speedup

### DIFF
--- a/server/src/integration/java/org/opentosca/toscana/core/csar/CsarServiceImplIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/core/csar/CsarServiceImplIT.java
@@ -16,12 +16,14 @@ import org.opentosca.toscana.model.EffectiveModelFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class CsarServiceImplIT extends BaseSpringIntegrationTest {
 
     private final String identifier = "my-awesome-csar";

--- a/server/src/test/java/org/opentosca/toscana/core/BaseSpringTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/BaseSpringTest.java
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -26,7 +25,6 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {TestCoreConfiguration.class})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @TestPropertySource("classpath:test-properties.yml")
 public abstract class BaseSpringTest extends BaseTest {
 


### PR DESCRIPTION
Instead of renewing the spring context after every test method, renewing the context after every test class is sufficient for all test classes besides `CsarServiceImplTest`.
This patch changes the default behaviour to `clear context after every test class`.

It could be risky tough to apply this now after some tests have been written. What do you think?