### PR TITLE
Rework Docker build Log output

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/image/ImageBuilder.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/image/ImageBuilder.java
@@ -2,6 +2,7 @@ package org.opentosca.toscana.plugins.kubernetes.docker.image;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Consumer;
 
 import org.opentosca.toscana.core.plugin.PluginFileAccess;
 import org.opentosca.toscana.core.transformation.TransformationContext;
@@ -64,17 +65,31 @@ public abstract class ImageBuilder implements ProgressHandler {
 
     @Override
     public void progress(ProgressMessage progressMessage) throws DockerException {
-        String stream = progressMessage.stream();
-        String error = progressMessage.error();
-        String progress = progressMessage.progress();
-        if (stream != null) {
-            logger.info(stream.replace("\n", " "));
-        }
-        if (progress != null) {
-            logger.trace(progress.replace("\n", " "));
-        }
-        if (error != null) {
-            logger.error(error.replace("\n", " "));
+        if (logger.isDebugEnabled())
+            log(progressMessage.progress(), logger::trace);
+        log(progressMessage.stream(), logger::info);
+        log(progressMessage.error(), logger::error);
+        log(progressMessage.status(), logger::info);
+    }
+
+    private String cleanString(String s) {
+        //Replace Carriage Return with newline
+        return s.replace((char) 0x0D, (char) 0x0A);
+    }
+
+    private void log(String s, Consumer<String> loggingFunc) {
+
+        if (s != null) {
+            String[] lines = s.split("\n");
+            for (String line : lines) {
+                String[] cleanLine = cleanString(line).split("\n");
+                for (String partialLine : cleanLine) {
+                    if (partialLine.replace(" ", "").length() == 0) {
+                        continue;
+                    }
+                    loggingFunc.accept(partialLine);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This pr removes the ugly blank spots in the logs created when running a transfromation on kubernetes.

The cause for this is the [Carriage Return](https://en.wikipedia.org/wiki/Carriage_return) character that deleted the whole line while rendering in any kind of terminal.

This probably resolves #464 

A example output of the new version can be seen here:
https://gist.github.com/c-mueller/21355bfaf0e5f1150bd0bd90686703c0
