### PR TITLE
Fix kubernetes image mapper

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
@@ -47,7 +47,7 @@ public class DockerRegistry {
      <p>
      This is a list, because the api splits this into pages
      */
-    public List<ImageTags> getTagsForRepository(String user, String repository) {
+    public List<ImageTags> getTagsForRepository(String user, String repository) throws IOException {
         Object next;
         int page = 1;
         List<ImageTags> imageTags = new ArrayList<>();
@@ -62,7 +62,7 @@ public class DockerRegistry {
                 next = response.body().getNext();
                 page++;
             } catch (Exception e) {
-                logger.error("Execution of the request failed", e);
+                logger.error("Execution of the request failed");
                 logger.error("Processing failed: For {}/{} (Page {}) on '{}'", user, repository, page, baseUrl);
                 try {
                     logger.error("The Server responded '{}'", (response != null &&
@@ -71,7 +71,7 @@ public class DockerRegistry {
                     logger.error("Printing error response failed.", ex);
                     ex.printStackTrace();
                 }
-                return imageTags;
+                throw e;
             }
         } while (next != null);
         return imageTags;

--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/mapper/api/DockerRegistry.java
@@ -65,7 +65,8 @@ public class DockerRegistry {
                 logger.error("Execution of the request failed", e);
                 logger.error("Processing failed: For {}/{} (Page {}) on '{}'", user, repository, page, baseUrl);
                 try {
-                    logger.error("The Server responded {}", (response.errorBody() != null) ? response.errorBody().string() : "");
+                    logger.error("The Server responded '{}'", (response != null &&
+                        response.errorBody() != null) ? response.errorBody().string() : "");
                 } catch (Exception ex) {
                     logger.error("Printing error response failed.", ex);
                     ex.printStackTrace();


### PR DESCRIPTION
When having no internet connection and starting the server, the server tricked himself into believing that he downloaded the docker base image mappings although he failed (UnknownHostException). After restarting the server (even with internet connection) he refused to redownload the mappings (Next persist: 24h..).

This patch fixes this behaviour.