### PR TITLE
GET transformation/properties allowed even after transformation is done

### DIFF
--- a/server/src/integration/java/org/opentosca/toscana/core/GetPropertiesIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/core/GetPropertiesIT.java
@@ -1,0 +1,31 @@
+package org.opentosca.toscana.core;
+
+import java.io.IOException;
+
+import org.opentosca.toscana.core.testdata.TestCsars;
+import org.opentosca.toscana.retrofit.BlockingToscanaApi;
+import org.opentosca.toscana.retrofit.TOSCAnaAPI;
+import org.opentosca.toscana.retrofit.model.Transformation;
+import org.opentosca.toscana.retrofit.util.TOSCAnaServerException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GetPropertiesIT extends BaseSpringIntegrationTest {
+
+    /**
+     Tests whether transformation inputs can be retrieved when the Transformation reached state DONE or ERROR.
+     */
+    @Test
+    public void getInputsAfterTransformationTest() throws IOException, TOSCAnaServerException {
+        TOSCAnaAPI api = new BlockingToscanaApi(getHttpUrl());
+        String csarName = "csarname";
+        api.uploadCsar(csarName, TestCsars.VALID_EMPTY_TOPOLOGY);
+        String platformId = "kubernetes";
+        api.createTransformation(csarName, platformId);
+        api.startTransformation(csarName, platformId);
+        assertEquals(Transformation.TransformationState.DONE, api.getTransformation(csarName, platformId).getState());
+        api.getProperties(csarName, platformId);
+    }
+}

--- a/server/src/integration/java/org/opentosca/toscana/core/UserInputIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/core/UserInputIT.java
@@ -21,9 +21,9 @@ import static org.junit.Assert.assertEquals;
 public class UserInputIT extends BaseSpringIntegrationTest {
 
     private TOSCAnaAPI api;
-    String csarName = "lamp";
-    String platformId = new CloudFoundryPlugin().getPlatform().id;
-    TransformationProperties properties;
+    private String csarName = "lamp";
+    private String platformId = new CloudFoundryPlugin().getPlatform().id;
+    private TransformationProperties properties;
 
     @Before
     public void setUp() throws IOException, TOSCAnaServerException {

--- a/server/src/main/java/org/opentosca/toscana/api/TransformationController.java
+++ b/server/src/main/java/org/opentosca/toscana/api/TransformationController.java
@@ -672,7 +672,6 @@ public class TransformationController {
     ) {
         Csar csar = findByCsarId(csarId);
         Transformation transformation = findTransformationByPlatform(csar, platformId);
-        checkTransformationState(transformation);
         List<PropertyWrap> propertyWrapList = toPropertyWrapList(transformation.getProperties(), null);
         GetPropertiesResponse response = new GetPropertiesResponse(csarId, platformId, propertyWrapList);
         return ResponseEntity.ok(response);


### PR DESCRIPTION
## Issue
1. Transformation state is 'DONE'
2. Call to `GET ../<transformation>/properties` returns `400: Transformation is in illegal state` (not literally)

## Fix
`GET ../<transformation>/properties` is allowed in any transformation state.