### PR TITLE
Reject duplicated csar ID on upload

### DIFF
--- a/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/ToscanaApi.java
+++ b/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/ToscanaApi.java
@@ -259,7 +259,7 @@ public class ToscanaApi {
     ) throws TOSCAnaServerException, IOException {
         ResponseBody errorBody = response.errorBody();
         TOSCAnaServerException exception = new TOSCAnaServerException(
-            "Execution of HTTP call " + call.request().url() + " failed",
+            String.format("Execution of HTTP call %s failed", call.request().url()),
             errorBody == null || errorBody.contentLength() == 0 ?
                 null : objectMapper.readValue(errorBody.string(), ServerError.class),
             response.code()

--- a/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/util/TOSCAnaServerException.java
+++ b/retrofit-wrapper/src/main/java/org/opentosca/toscana/retrofit/util/TOSCAnaServerException.java
@@ -27,7 +27,9 @@ public class TOSCAnaServerException extends Exception {
 
     public void printLog() {
         System.err.printf("%s: %s%n", getMessage(), getStatusCode());
-        System.err.printf("%s: %n%s%n", getErrorResponse().getException(), getErrorResponse().getMessage());
-        errorResponse.getLogs().stream().forEach(System.err::println);
+        if (errorResponse != null) {
+            System.err.printf("%s: %n%s%n", getErrorResponse().getException(), getErrorResponse().getMessage());
+            errorResponse.getLogs().stream().forEach(System.err::println);
+        }
     }
 }

--- a/server/src/integration/java/org/opentosca/toscana/core/UserInputIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/core/UserInputIT.java
@@ -12,12 +12,14 @@ import org.opentosca.toscana.retrofit.util.TOSCAnaServerException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  Tests whether user inputs are correctly propagated into the EffectiveModel and provided for the transformation.
  */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class UserInputIT extends BaseSpringIntegrationTest {
 
     private ToscanaApi api;

--- a/server/src/integration/java/org/opentosca/toscana/core/csar/CsarServiceImplIT.java
+++ b/server/src/integration/java/org/opentosca/toscana/core/csar/CsarServiceImplIT.java
@@ -2,6 +2,7 @@ package org.opentosca.toscana.core.csar;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -19,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -38,7 +40,7 @@ public class CsarServiceImplIT extends BaseSpringIntegrationTest {
         EffectiveModelFactory modelFactory = mock(EffectiveModelFactory.class);
         EffectiveModel model = modelMock();
         when(modelFactory.create(any(Csar.class))).thenReturn(model);
-        csarService = new CsarServiceImpl(csarDao, modelFactory);
+        csarService = new CsarServiceImpl(csarDao);
         Log log = new LogImpl(new File(tmpdir, "log"));
         csar = new CsarImpl(new File(""), identifier, log);
     }
@@ -50,6 +52,21 @@ public class CsarServiceImplIT extends BaseSpringIntegrationTest {
 
         Csar result = csarService.submitCsar(identifier, stream);
         assertEquals(csar, result);
+    }
+
+    @Test(expected = CsarIdNotUniqueException.class)
+    public void submitCsarTwice() throws FileNotFoundException, InvalidCsarException, CsarIdNotUniqueException {
+        File file = TestCsars.VALID_EMPTY_TOPOLOGY;
+        InputStream stream = new FileInputStream(file);
+
+        try {
+            csarService.submitCsar(identifier, stream);
+        } catch (InvalidCsarException | CsarIdNotUniqueException e) {
+            e.printStackTrace();
+            fail();
+        }
+        stream = new FileInputStream(file);
+        csarService.submitCsar(identifier, stream);
     }
 
     @Test

--- a/server/src/main/java/org/opentosca/toscana/api/CsarController.java
+++ b/server/src/main/java/org/opentosca/toscana/api/CsarController.java
@@ -159,7 +159,7 @@ public class CsarController {
         ),
         @ApiResponse(
             code = 406,
-            message = "cSAR upload rejected - given ID already in use",
+            message = "CSAR upload rejected - given ID already in use",
             response = Void.class
         ),
         @ApiResponse(

--- a/server/src/main/java/org/opentosca/toscana/api/docs/HttpLogger.java
+++ b/server/src/main/java/org/opentosca/toscana/api/docs/HttpLogger.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HttpLogger implements TraceRepository {
 
-    private static final Logger LOG = LoggerFactory.getLogger(HttpLogger.class);
+    private static final Logger logger = LoggerFactory.getLogger(HttpLogger.class);
     private final TraceRepository delegate = new InMemoryTraceRepository();
 
     @Override
@@ -33,7 +33,7 @@ public class HttpLogger implements TraceRepository {
 //        Map<String, String> requestMap = headerMap.get("request");
         Map<String, String> responseMap = headerMap.get("response");
         String responseStatus = responseMap.get("status");
-        LOG.info("Request: \"{} {}\", response: {} after {}ms", method, path, responseStatus, timeTaken);
+        logger.debug("Request: \"{} {}\", response: {} after {}ms", method, path, responseStatus, timeTaken);
         this.delegate.add(traceInfo);
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/core/csar/CsarIdNotUniqueException.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/CsarIdNotUniqueException.java
@@ -1,0 +1,8 @@
+package org.opentosca.toscana.core.csar;
+
+public class CsarIdNotUniqueException extends Exception {
+
+    public CsarIdNotUniqueException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/core/csar/CsarService.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/CsarService.java
@@ -16,8 +16,10 @@ public interface CsarService {
      @return the newly created Csar instance
      @throws InvalidCsarException if parsing, based on the content of given csarStream, failed The exception contains
      the parsing log)
+     
+     @throws CsarIdNotUniqueException if a csar with the same identifier already exists
      */
-    Csar submitCsar(String identifier, InputStream csarStream) throws InvalidCsarException;
+    Csar submitCsar(String identifier, InputStream csarStream) throws InvalidCsarException, CsarIdNotUniqueException;
 
     /**
      Deletes given Csar and all associated transformations from in-memory and persistence layer.

--- a/server/src/main/java/org/opentosca/toscana/core/csar/CsarServiceImpl.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/CsarServiceImpl.java
@@ -4,8 +4,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 
-import org.opentosca.toscana.model.EffectiveModelFactory;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,20 +11,22 @@ import org.springframework.stereotype.Service;
 public class CsarServiceImpl implements CsarService {
 
     private final CsarDao csarDao;
-    private final EffectiveModelFactory effectiveModelFactory;
 
     @Autowired
-    public CsarServiceImpl(CsarDao dao, EffectiveModelFactory effectiveModelFactory) {
+    public CsarServiceImpl(CsarDao dao) {
         this.csarDao = dao;
-        this.effectiveModelFactory = effectiveModelFactory;
     }
 
     @Override
-    public Csar submitCsar(String identifier, InputStream csarStream) {
-        Csar csar = csarDao.create(identifier, csarStream);
-        csar.validate();
-        csar.getLog().close();
-        return csar;
+    public Csar submitCsar(String identifier, InputStream csarStream) throws CsarIdNotUniqueException {
+        if (!csarDao.find(identifier).isPresent()) {
+            Csar csar = csarDao.create(identifier, csarStream);
+            csar.validate();
+            csar.getLog().close();
+            return csar;
+        } else {
+            throw new CsarIdNotUniqueException("Csar id " + identifier + " already in use");
+        }
     }
 
     @Override

--- a/server/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
+++ b/server/src/test/java/org/opentosca/toscana/core/TestCoreConfiguration.java
@@ -67,7 +67,7 @@ public class TestCoreConfiguration extends CoreConfiguration {
 
     @Bean
     public CsarService csarService(CsarDao repo) {
-        return new CsarServiceImpl(repo, effectiveModelFactory());
+        return new CsarServiceImpl(repo);
     }
 
     @Bean


### PR DESCRIPTION
Currently, uploading a csar taking an already used ID results in overriding the old csar.

With this patch, uploading a csar with non-unique ID will get rejected (406).