### PR TITLE
Fix: Dockerd not running in Docker Image

### DIFF
--- a/docker/alpine-dind/toscana-dind-entrypoint.sh
+++ b/docker/alpine-dind/toscana-dind-entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-dockerd &
+
+# Launch Dockerd
+docker_logfile=/var/log/dockerd.log
+touch $docker_logfile
+while true; do dockerd | tee -a $docker_logfile; done &
+
+# Launch Toscana
 logfile=/var/log/toscana.log
 touch $logfile
 java -jar server.jar | tee -a $logfile


### PR DESCRIPTION
While experimenting with the webapp, i encountered a problem with the Docker Daemon in the Docker image. For some reason it decided to crash. After "sshing" (well kind of) into the container to restart the `dockerd` it worked again. Thats why i'm putting it into a loop. So in case of a crash it just restarts