### PR TITLE
Add support for keyword 'UNBOUNDED' and fix ScalableCapability

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/core/parse/converter/ScalarTypeConverter.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/converter/ScalarTypeConverter.java
@@ -1,0 +1,70 @@
+package org.opentosca.toscana.core.parse.converter;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.opentosca.toscana.core.parse.model.Connection;
+import org.opentosca.toscana.core.parse.model.Entity;
+import org.opentosca.toscana.core.parse.model.ScalarEntity;
+import org.opentosca.toscana.model.datatype.Port;
+import org.opentosca.toscana.model.datatype.SizeUnit;
+import org.opentosca.toscana.model.operation.OperationVariable;
+import org.opentosca.toscana.model.util.ToscaKey;
+
+import org.apache.commons.lang3.EnumUtils;
+
+public class ScalarTypeConverter {
+
+    /**
+     TOSCA keyword 'UNBOUNDED' represents an unlimited positive integer
+     */
+    public static final String UNBOUNDED = "UNBOUNDED";
+
+    static <T> T convertScalarEntity(ScalarEntity scalarEntity, ToscaKey<T> key, Entity parent) {
+        String value = scalarEntity.getValue();
+        Class targetType = key.getType();
+        if (String.class.isAssignableFrom(targetType)) {
+            return (T) value;
+        } else if (Integer.class.isAssignableFrom(targetType)) {
+            Integer number;
+            if (UNBOUNDED.equals(value)) {
+                number = Integer.MAX_VALUE;
+            } else {
+                number = Integer.valueOf(value);
+            }
+            return (T) number;
+        } else if (Boolean.class.isAssignableFrom(targetType)) {
+            return (T) Boolean.valueOf(value);
+            // TODO handle values besides true/false (later, when doing error handling)
+        } else if (targetType.isEnum()) {
+            Map<String, T> enumMap = EnumUtils.getEnumMap(targetType);
+            Optional<T> result = enumMap.entrySet().stream()
+                .filter(entry -> value.equalsIgnoreCase(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .findAny();
+            return result.orElseThrow(() -> new NoSuchElementException(
+                String.format("No value with name '%s' in enum '%s'", value, targetType.getSimpleName())));
+        } else if (OperationVariable.class.isAssignableFrom(targetType)) {
+            Connection c = scalarEntity.getGraph().getEdge(parent, scalarEntity);
+            String name = null;
+            if (c != null) {
+                name = c.getKey();
+            }
+            return (T) new OperationVariable(scalarEntity, name);
+        } else if (SizeUnit.class.isAssignableFrom(targetType)) {
+            SizeUnit.Unit fromDefaultUnit = (SizeUnit.Unit) key.getDirectives().get(SizeUnit.FROM);
+            SizeUnit.Unit toUnit = (SizeUnit.Unit) key.getDirectives().get(SizeUnit.TO);
+            if (fromDefaultUnit == null || toUnit == null) {
+                throw new IllegalStateException(
+                    "ToscaKey defining a SizeUnit is illegal: No directive set for source and target units");
+            }
+            return (T) SizeUnit.convert(value, fromDefaultUnit, toUnit);
+        } else if (Port.class.isAssignableFrom(targetType)) {
+            return (T) new Port(Integer.valueOf(value));
+        } else {
+            throw new UnsupportedOperationException(String.format(
+                "Cannot convert value of type %s: currently unsupported", targetType.getSimpleName()));
+        }
+    }
+}

--- a/server/src/main/java/org/opentosca/toscana/core/parse/converter/TypeConverter.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/converter/TypeConverter.java
@@ -1,21 +1,11 @@
 package org.opentosca.toscana.core.parse.converter;
 
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import org.opentosca.toscana.core.parse.converter.util.AttributeNotSetException;
-import org.opentosca.toscana.core.parse.model.Connection;
 import org.opentosca.toscana.core.parse.model.Entity;
 import org.opentosca.toscana.core.parse.model.MappingEntity;
 import org.opentosca.toscana.core.parse.model.ScalarEntity;
 import org.opentosca.toscana.model.BaseToscaElement;
-import org.opentosca.toscana.model.datatype.Port;
-import org.opentosca.toscana.model.datatype.SizeUnit;
-import org.opentosca.toscana.model.operation.OperationVariable;
 import org.opentosca.toscana.model.util.ToscaKey;
-
-import org.apache.commons.lang3.EnumUtils;
 
 @SuppressWarnings("unchecked")
 public class TypeConverter {
@@ -30,54 +20,13 @@ public class TypeConverter {
             }
         } else if (entity instanceof ScalarEntity) {
             ScalarEntity scalarEntity = (ScalarEntity) entity;
-            return convertScalarEntity(scalarEntity, key, parent);
+            return ScalarTypeConverter.convertScalarEntity(scalarEntity, key, parent);
         } else if (BaseToscaElement.class.isAssignableFrom(key.getType())) {
             MappingEntity mappingEntity = (MappingEntity) entity;
             return TypeWrapper.wrapEntity(mappingEntity, key.getType());
         } else {
             throw new IllegalStateException(
                 String.format("Cannot get value of type '%s' from entity '%s'", key.getType(), entity));
-        }
-    }
-
-    private static <T> T convertScalarEntity(ScalarEntity scalarEntity, ToscaKey<T> key, Entity parent) {
-        String value = scalarEntity.getValue();
-        Class targetType = key.getType();
-        if (String.class.isAssignableFrom(targetType)) {
-            return (T) value;
-        } else if (Integer.class.isAssignableFrom(targetType)) {
-            return (T) Integer.valueOf(value);
-        } else if (Boolean.class.isAssignableFrom(targetType)) {
-            return (T) Boolean.valueOf(value);
-            // TODO handle values besides true/false (later, when doing error handling)
-        } else if (targetType.isEnum()) {
-            Map<String, T> enumMap = EnumUtils.getEnumMap(targetType);
-            Optional<T> result = enumMap.entrySet().stream()
-                .filter(entry -> value.equalsIgnoreCase(entry.getKey()))
-                .map(Map.Entry::getValue)
-                .findAny();
-            return result.orElseThrow(() -> new NoSuchElementException(
-                String.format("No value with name '%s' in enum '%s'", value, targetType.getSimpleName())));
-        } else if (OperationVariable.class.isAssignableFrom(targetType)) {
-            Connection c = scalarEntity.getGraph().getEdge(parent, scalarEntity);
-            String name = null;
-            if (c != null) {
-                name = c.getKey();
-            }
-            return (T) new OperationVariable(scalarEntity, name);
-        } else if (SizeUnit.class.isAssignableFrom(targetType)) {
-            SizeUnit.Unit fromDefaultUnit = (SizeUnit.Unit) key.getDirectives().get(SizeUnit.FROM);
-            SizeUnit.Unit toUnit = (SizeUnit.Unit) key.getDirectives().get(SizeUnit.TO);
-            if (fromDefaultUnit == null || toUnit == null) {
-                throw new IllegalStateException(
-                    "ToscaKey defining a SizeUnit is illegal: No directive set for source and target units");
-            }
-            return (T) SizeUnit.convert(value, fromDefaultUnit, toUnit);
-        } else if (Port.class.isAssignableFrom(targetType)) {
-            return (T) new Port(Integer.valueOf(value));
-        } else {
-            throw new UnsupportedOperationException(String.format(
-                "Cannot convert value of type %s: currently unsupported", targetType.getSimpleName()));
         }
     }
 }

--- a/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
+++ b/server/src/main/java/org/opentosca/toscana/model/capability/ScalableCapability.java
@@ -19,24 +19,23 @@ public class ScalableCapability extends Capability {
 
     /**
      Indicates the maximum number of instances that should be created for the associated node.
-     <p>
-     Same as the max value of the Range connected to #SCALE_RANGE
      */
-    public static ToscaKey<Integer> MAX_INSTANCES = new ToscaKey<>(PROPERTIES, "min_instances");
+    public static ToscaKey<Integer> MAX_INSTANCES = new ToscaKey<>(PROPERTIES, "max_instances")
+        .type(Integer.class);
 
     /**
      Indicates the minimum number of instances that should be created for the associated node.
-     <p>
-     Same as the min value of the Range connected to #SCALE_RANGE
      */
-    public static ToscaKey<Integer> MIN_INSTANCES = new ToscaKey<>(PROPERTIES, "max_instances");
+    public static ToscaKey<Integer> MIN_INSTANCES = new ToscaKey<>(PROPERTIES, "min_instances")
+        .type(Integer.class);
 
     /**
      The optional default number of instances that should be the starting number of instances
      a TOSCA orchestrator should attempt to allocate.
      (TOSCA Simple Profile in YAML Version 1.1, p. 157)
      */
-    public static ToscaKey<Integer> DEFAULT_INSTANCES = new ToscaKey<>(PROPERTIES, "default_instances");
+    public static ToscaKey<Integer> DEFAULT_INSTANCES = new ToscaKey<>(PROPERTIES, "default_instances")
+        .type(Integer.class);
 
     public ScalableCapability(MappingEntity mappingEntity) {
         super(mappingEntity);

--- a/server/src/test/java/org/opentosca/toscana/core/parse/TestTemplates.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/TestTemplates.java
@@ -11,6 +11,7 @@ public class TestTemplates {
     private static final File TOSCA_ELEMENTS = new File(BASE_PATH, "tosca_elements");
     private static final File DATATYPES = new File(BASE_PATH, "datatypes");
     private static final File NODES = new File(TOSCA_ELEMENTS, "nodes");
+    private static final File CAPABILITIES = new File(TOSCA_ELEMENTS, "capabilities");
 
     public static class Normalization {
         public static final File REPOSITORY = new File(NORMALIZATION, "repository_norm.yaml");
@@ -35,6 +36,10 @@ public class TestTemplates {
         public static final File SOFTWARE_COMPONENT = new File(NODES, "software-component.yaml");
     }
 
+    public static class Capabilities {
+        public static final File SCALABLE = new File(CAPABILITIES, "scalable.yaml");
+    }
+
     public static class ToscaElements {
         public static final File REPOSITORY = new File(TOSCA_ELEMENTS, "repository.yaml");
         public static final File CREDENTIAL = new File(TOSCA_ELEMENTS, "credential.yaml");
@@ -46,7 +51,7 @@ public class TestTemplates {
         public static final File REQUIREMENT = new File(TOSCA_ELEMENTS, "requirement.yaml");
         public static final File NODE = new File(TOSCA_ELEMENTS, "node.yaml");
     }
-    
+
     public static class Datatypes {
         public static final File PORT = new File(DATATYPES, "port.yaml");
     }

--- a/server/src/test/java/org/opentosca/toscana/core/parse/model/ScalableCapabilityTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/parse/model/ScalableCapabilityTest.java
@@ -1,0 +1,25 @@
+package org.opentosca.toscana.core.parse.model;
+
+import org.opentosca.toscana.core.BaseUnitTest;
+import org.opentosca.toscana.core.parse.TestTemplates;
+import org.opentosca.toscana.model.EffectiveModel;
+import org.opentosca.toscana.model.EffectiveModelFactory;
+import org.opentosca.toscana.model.capability.ScalableCapability;
+import org.opentosca.toscana.model.node.Compute;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScalableCapabilityTest extends BaseUnitTest {
+
+    @Test
+    public void scalableTest() {
+        EffectiveModel model = new EffectiveModelFactory().create(TestTemplates.Capabilities.SCALABLE, logMock());
+        Compute compute = (Compute) model.getNodes().iterator().next();
+        ScalableCapability scalable = compute.getScalable();
+        assertEquals(5, (int) scalable.getMinInstances());
+        assertEquals(7, (int) scalable.getDefaultInstances().get());
+        assertEquals(Integer.MAX_VALUE, (int) scalable.getMaxInstances());
+    }
+}

--- a/server/src/test/resources/converter/tosca_elements/capabilities/scalable.yaml
+++ b/server/src/test/resources/converter/tosca_elements/capabilities/scalable.yaml
@@ -1,0 +1,18 @@
+tosca_definitions_version: tosca_simple_yaml_1_1
+
+description: a template for testing the ScalableCapability
+metadata:
+  template_name: scalable
+  template_author: stupro-toscana
+  template_version: 1.0
+
+topology_template:
+  node_templates:
+    scalable-compute:
+      type: Compute
+      capabilities:
+        scalable: 
+          properties: 
+            min_instances: 5 
+            max_instances: UNBOUNDED
+            default_instances: 7 


### PR DESCRIPTION
This pr adds following:
- Support for keyword 'UNBOUNDED'; for every TOSCA integer, 'UNBOUNDED' can be used in the template, which internally gets translated to Integer.MAX_VALUE
- Fix bugs in ScalableCapability