### PR TITLE
Write transformation related log entries to transformation log

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/core/csar/Csar.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/Csar.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.opentosca.toscana.core.parse.InvalidCsarException;
 import org.opentosca.toscana.core.plugin.lifecycle.LifecyclePhase;
 import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.logging.Log;
@@ -53,6 +54,12 @@ public interface Csar extends LifecycleAccess {
      */
     File getContentDir();
 
+    /**
+     Returns the service template of this csar
+     @return
+     */
+    File getTemplate() throws InvalidCsarException;
+    
     enum Phase {
         UNZIP("unzip"),
         VALIDATE("validate"),
@@ -68,4 +75,5 @@ public interface Csar extends LifecycleAccess {
             return name;
         }
     }
+    
 }

--- a/server/src/main/java/org/opentosca/toscana/core/csar/CsarImpl.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/CsarImpl.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.opentosca.toscana.core.parse.EntrypointDetector;
 import org.opentosca.toscana.core.parse.InvalidCsarException;
 import org.opentosca.toscana.core.plugin.lifecycle.LifecyclePhase;
 import org.opentosca.toscana.core.transformation.Transformation;
@@ -34,6 +33,7 @@ public class CsarImpl implements Csar {
     private final Logger logger;
     private final File rootDir;
     private final File contentDir;
+    private File template;
     private final List<LifecyclePhase> lifecyclePhases;
 
     public CsarImpl(File rootDir, String identifier, Log log) {
@@ -66,8 +66,7 @@ public class CsarImpl implements Csar {
         logger.info("Validating csar '{}'", identifier);
         logger.debug("  > Validating TOSCA template", identifier);
         try {
-            File entryPoint = new EntrypointDetector(this.log).findEntryPoint(this.contentDir);
-            Reader.getReader().parse(Paths.get(this.contentDir.toString()), Paths.get(entryPoint.toString()));
+            Reader.getReader().parse(Paths.get(this.contentDir.toString()), Paths.get(getTemplate().toString()));
             logger.info("Template validation successful");
             phase.setState(LifecyclePhase.State.DONE);
             return true;
@@ -153,6 +152,14 @@ public class CsarImpl implements Csar {
     @Override
     public File getContentDir() {
         return contentDir;
+    }
+
+    @Override
+    public File getTemplate() throws InvalidCsarException {
+        if (template == null) {
+            template = new EntrypointDetector(log).findEntryPoint(contentDir);
+        }
+        return template;
     }
 
     @Override

--- a/server/src/main/java/org/opentosca/toscana/core/csar/CustomTypeInjector.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/CustomTypeInjector.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.opentosca.toscana.core.parse.EntrypointDetector;
 import org.opentosca.toscana.core.parse.InvalidCsarException;
 import org.opentosca.toscana.core.transformation.logging.Log;
 
@@ -32,7 +31,7 @@ public class CustomTypeInjector {
      */
     public void inject(Csar csar) {
         try {
-            File serviceTemplate = new EntrypointDetector(log).findEntryPoint(csar.getContentDir());
+            File serviceTemplate = csar.getTemplate();
             String templateContent = FileUtils.readFileToString(serviceTemplate);
             List<String> template = Lists.newArrayList(templateContent.split("\n"));
 

--- a/server/src/main/java/org/opentosca/toscana/core/csar/EntrypointDetector.java
+++ b/server/src/main/java/org/opentosca/toscana/core/csar/EntrypointDetector.java
@@ -1,8 +1,9 @@
-package org.opentosca.toscana.core.parse;
+package org.opentosca.toscana.core.csar;
 
 import java.io.File;
 import java.util.Objects;
 
+import org.opentosca.toscana.core.parse.InvalidCsarException;
 import org.opentosca.toscana.core.transformation.logging.Log;
 
 import org.slf4j.Logger;
@@ -12,7 +13,7 @@ public class EntrypointDetector {
     private final Logger logger;
     private final Log log;
 
-    public EntrypointDetector(Log log) {
+    EntrypointDetector(Log log) {
         this.log = Objects.requireNonNull(log);
         this.logger = log.getLogger(getClass());
     }
@@ -25,7 +26,7 @@ public class EntrypointDetector {
      @return the entry point yaml file of given csar
      @throws InvalidCsarException if no or more than one top level yaml file was found in given csar
      */
-    public File findEntryPoint(File csarRoot) throws InvalidCsarException {
+    File findEntryPoint(File csarRoot) throws InvalidCsarException {
         File[] entryPoints = csarRoot.listFiles((file, s) -> s.matches(".*\\.ya?ml$"));
         if (entryPoints == null) {
             logger.error(String.format("Given directory '%s' does not exist", csarRoot));

--- a/server/src/main/java/org/opentosca/toscana/core/parse/model/Entity.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/model/Entity.java
@@ -116,7 +116,8 @@ public abstract class Entity implements Comparable<Entity> {
                     T value = TypeConverter.convert(grandChild, key, child.get());
                     values.add(value);
                 } catch (AttributeNotSetException e) {
-                    logger.warn("Trying to access an unset attribute - skipping.", e);
+                    logger.warn("Trying to access an unset attribute - skipping.");
+                    logger.warn(e.getMessage());
                 }
             }
         }

--- a/server/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
+++ b/server/src/main/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDao.java
@@ -71,9 +71,9 @@ public class TransformationFilesystemDao implements TransformationDao {
 
     private Transformation createTransformation(Csar csar, Platform platform) {
         try {
-            EffectiveModel model = effectiveModelFactory.create(csar);
-            Transformation transformation = new TransformationImpl(csar, platform, getLog(csar, platform), model);
-            return transformation;
+            Log log = getLog(csar, platform);
+            EffectiveModel model = effectiveModelFactory.create(csar.getTemplate(), log);
+            return new TransformationImpl(csar, platform, getLog(csar, platform), model);
         } catch (InvalidCsarException e) {
             throw new IllegalStateException("Failed to create csar. Should not have happened - csar upload should have" +
                 "already failed", e);

--- a/server/src/main/java/org/opentosca/toscana/model/EffectiveModel.java
+++ b/server/src/main/java/org/opentosca/toscana/model/EffectiveModel.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.opentosca.toscana.core.csar.Csar;
-import org.opentosca.toscana.core.parse.EntrypointDetector;
 import org.opentosca.toscana.core.parse.InvalidCsarException;
 import org.opentosca.toscana.core.parse.ToscaTemplateException;
 import org.opentosca.toscana.core.parse.converter.TypeWrapper;
@@ -35,21 +34,13 @@ public class EffectiveModel {
     private boolean initialized = false;
 
     protected EffectiveModel(Csar csar) throws InvalidCsarException {
-        this.log = csar.getLog();
-        this.logger = log.getLogger(getClass());
-        try {
-            logger.info("Constructing TOSCA element graph");
-            EntrypointDetector entrypointDetector = new EntrypointDetector(log);
-            File template = entrypointDetector.findEntryPoint(csar.getContentDir());
-            this.serviceGraph = new ServiceGraph(template, csar.getLog());
-        } catch (Exception e) {
-            throw e;
-        }
+        this(csar.getTemplate(), csar.getLog());
     }
 
     protected EffectiveModel(File template, Log log) {
         this.log = log;
         this.logger = log.getLogger(getClass());
+        logger.info("Constructing TOSCA element graph");
         this.serviceGraph = new ServiceGraph(template, log);
     }
 

--- a/server/src/main/java/org/opentosca/toscana/model/EffectiveModelFactory.java
+++ b/server/src/main/java/org/opentosca/toscana/model/EffectiveModelFactory.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.parse.InvalidCsarException;
+import org.opentosca.toscana.core.transformation.Transformation;
 import org.opentosca.toscana.core.transformation.logging.Log;
 
 import org.springframework.stereotype.Service;

--- a/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationDaoUnitTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationDaoUnitTest.java
@@ -9,6 +9,7 @@ import org.opentosca.toscana.core.csar.Csar;
 import org.opentosca.toscana.core.csar.CsarDao;
 import org.opentosca.toscana.core.csar.CsarImpl;
 import org.opentosca.toscana.core.parse.InvalidCsarException;
+import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.platform.PlatformService;
 import org.opentosca.toscana.core.util.Preferences;
 import org.opentosca.toscana.model.EffectiveModel;
@@ -21,7 +22,9 @@ import org.mockito.Mock;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.opentosca.toscana.core.testdata.TestPlugins.PLATFORM1;
 
@@ -42,7 +45,9 @@ public class TransformationDaoUnitTest extends BaseUnitTest {
     public void setUp() throws IOException, InvalidCsarException {
         when(platformService.findPlatformById(PLATFORM1.id)).thenReturn(Optional.ofNullable(PLATFORM1));
         when(preferences.getDataDir()).thenReturn(tmpdir);
-        csar = new CsarImpl(new File(""), "csarIdentifier", logMock());
+        Log log = logMock();
+        csar = spy(new CsarImpl(new File(""), "csarIdentifier", log));
+        doReturn(new File("")).when(csar).getTemplate();
         File csarTransformationDir = new File(tmpdir, "transformationDir");
         csarTransformationDir.mkdir();
         when(csarDao.getTransformationsDir(csar)).thenReturn(csarTransformationDir);
@@ -51,7 +56,8 @@ public class TransformationDaoUnitTest extends BaseUnitTest {
         File someTransformationFile = new File(platformDir, "some-file");
         someTransformationFile.createNewFile();
         EffectiveModelFactory modelFactory = mock(EffectiveModelFactory.class);
-        when(modelFactory.create(any(Csar.class))).thenReturn(mock(EffectiveModel.class));
+        EffectiveModel model = modelMock();
+        when(modelFactory.create(any(File.class), any(Log.class))).thenReturn(model);
 
         dao = new TransformationFilesystemDao(platformService, modelFactory);
         dao.setCsarDao(csarDao);

--- a/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDaoTest.java
+++ b/server/src/test/java/org/opentosca/toscana/core/transformation/TransformationFilesystemDaoTest.java
@@ -12,6 +12,7 @@ import org.opentosca.toscana.core.csar.CsarDao;
 import org.opentosca.toscana.core.csar.CsarFilesystemDao;
 import org.opentosca.toscana.core.csar.CsarImpl;
 import org.opentosca.toscana.core.parse.InvalidCsarException;
+import org.opentosca.toscana.core.transformation.logging.Log;
 import org.opentosca.toscana.core.transformation.platform.PlatformService;
 import org.opentosca.toscana.model.EffectiveModel;
 import org.opentosca.toscana.model.EffectiveModelFactory;
@@ -26,7 +27,9 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.opentosca.toscana.core.testdata.TestPlugins.PLATFORM1;
 import static org.opentosca.toscana.core.testdata.TestPlugins.PLATFORM2;
@@ -47,10 +50,11 @@ public class TransformationFilesystemDaoTest extends BaseUnitTest {
 
     @Before
     public void setUp() throws InvalidCsarException {
-        csar = new CsarImpl(new File(""), "csar1", logMock());
+        csar = spy(new CsarImpl(new File(""), "csar1", logMock()));
+        doReturn(new File("")).when(csar).getTemplate();
         EffectiveModelFactory modelFactory = mock(EffectiveModelFactory.class);
         EffectiveModel model = modelMock();
-        when(modelFactory.create(any(Csar.class))).thenReturn(model);
+        when(modelFactory.create(any(File.class), any(Log.class))).thenReturn(model);
         transformationDao = new TransformationFilesystemDao(platformService, modelFactory);
         transformationDao.setCsarDao(csarDao);
         transformation = new TransformationImpl(csar, PLATFORM1, logMock(), modelMock());
@@ -59,9 +63,9 @@ public class TransformationFilesystemDaoTest extends BaseUnitTest {
 
     @Test
     public void getRootDir() {
-        when(csarDao.getTransformationsDir(csar)).thenReturn(new File(new File(tmpdir, csar.getIdentifier()),
-            CsarFilesystemDao.TRANSFORMATION_DIR));
-        when(csarDao.getRootDir(csar)).thenReturn(new File(tmpdir, csar.getIdentifier()));
+        doReturn(new File(new File(tmpdir, csar.getIdentifier()),
+            CsarFilesystemDao.TRANSFORMATION_DIR)).when(csarDao).getTransformationsDir(csar);
+        doReturn(new File(tmpdir, csar.getIdentifier())).when(csarDao).getRootDir(csar);
         File expectedParent = new File(csarDao.getRootDir(csar), CsarFilesystemDao.TRANSFORMATION_DIR);
         File expected = new File(expectedParent, PLATFORM1.id);
         File actual = transformationDao.getRootDir(transformation);


### PR DESCRIPTION
When creating the transformation instance, the created EffectiveModel obtained the log instance of the CSAR and not the log instance of the transformation. This resulted in 'missing` log entries in the transformation log.
This PR fixes this issue.