### PR TITLE
Fix wrong operation variable key

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/core/parse/converter/ScalarTypeConverter.java
+++ b/server/src/main/java/org/opentosca/toscana/core/parse/converter/ScalarTypeConverter.java
@@ -48,10 +48,14 @@ public class ScalarTypeConverter {
         } else if (OperationVariable.class.isAssignableFrom(targetType)) {
             Connection c = scalarEntity.getGraph().getEdge(parent, scalarEntity);
             String name = null;
+            OperationVariable var;
             if (c != null) {
                 name = c.getKey();
+                var = new OperationVariable(scalarEntity, name);
+            } else {
+                var = new OperationVariable(scalarEntity);
             }
-            return (T) new OperationVariable(scalarEntity, name);
+            return (T) var;
         } else if (SizeUnit.class.isAssignableFrom(targetType)) {
             SizeUnit.Unit fromDefaultUnit = (SizeUnit.Unit) key.getDirectives().get(SizeUnit.FROM);
             SizeUnit.Unit toUnit = (SizeUnit.Unit) key.getDirectives().get(SizeUnit.TO);

--- a/server/src/main/java/org/opentosca/toscana/model/operation/OperationVariable.java
+++ b/server/src/main/java/org/opentosca/toscana/model/operation/OperationVariable.java
@@ -19,9 +19,19 @@ public class OperationVariable {
     private ScalarEntity backingEntity;
     private final String name;
 
+    /**
+     Use when the variable's key differs from the scalar entity's parent name (e.g., when the value is a function)
+     */
     public OperationVariable(ScalarEntity entity, @Nullable String name) {
         this.backingEntity = entity;
         this.name = name;
+    }
+
+    /**
+     Use when the variable's key is the scalar entity's parent name
+     */
+    public OperationVariable(ScalarEntity entity) {
+        this(entity, entity.getParent().get().getName());
     }
 
     public Optional<String> getValue() {
@@ -33,7 +43,7 @@ public class OperationVariable {
     }
 
     public String getKey() {
-        return (name != null) ? name : backingEntity.getName();
+        return name;
     }
 
     @Override


### PR DESCRIPTION
Resolves #526 
When retrieving an operation variable's key and the variable was not a symbolic link to another property, the `OperationVariable#getKey()` call always returned `value`.

This PR fixes that bug.