### PR TITLE
Reduce Maven Log Output in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ dist: trusty
 service: docker
 
 before_install:
-- wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest
+- wget -q -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest
   | jq -r .assets[0].browser_download_url)
 install:
-- mvn install -DskipTests -P build
+- mvn install -DskipTests -B -P build | grep -v "\[INFO\] Downloaded\|\[INFO\] Downloading"
 script:
 # Use verify on the Profile all to execute unit and integration tests.
-- mvn verify -P all
+- mvn verify -B -P all | grep -v "\[INFO\] Downloaded\|\[INFO\] Downloading"
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 - java -cp ~/codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r target/site/jacoco/jacoco.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn install -P build'
+                sh 'mvn install -B -P build'
                 archiveArtifacts(onlyIfSuccessful: true, artifacts: '**/target/*.jar')
             }
         }


### PR DESCRIPTION
This PR significantly reduces the amount of Log output produced. By:
- Adding the `-B` flag to maven calls in the `.travis.yml`
- Making the download of the Codacy jar silent (`wget -q`)
- Removing `[INFO] Downloaded` and `[INFO] Downloading` messages from mavens log output

Just a Small size comparison of the travis logs

|Revision|Bytes|Lines|
|---|---|---|
|`master`|4.311.596|18.870|
|`#546`|1.609.796|15.025|