### PR TITLE
[PROPOSAL] Use MkDocs to generate HTML Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ app/node
 **/.vscode
 
 !translator.jar
+site/

--- a/docs/building-docs.md
+++ b/docs/building-docs.md
@@ -1,0 +1,73 @@
+# Building the Documentation
+
+We use MkDocs, with the 'rtd-dropdown' theme, to build our documentation.
+
+## Installing MkDocs localy
+
+The first option to use MkDocs is to install it manually.
+
+### Install MkDocs itself
+
+To install MkDocs please consult the following installation guide:
+http://www.mkdocs.org/#installation
+
+### Install RTD-Dropdown theme
+
+We the ReadTheDocs - Dropdown theme. This can be installed using
+```
+sudo pip install mkdocs-rtd-dropdown
+```
+
+In case this command fails you can also clone the repository (https://github.com/cjsheets/mkdocs-rtd-dropdown) and run `sudo python3 setup.py install` to install the theme
+
+## Using the Docker-Image
+
+To make the process described above we created a Docker Image that contains all the programs needed to serve and build the documentation.
+
+The image assumes the Directory containing the `mkdocs.yml` is mounted at `/repo`
+
+The Commands shown below assume that your current working directory is the root folder in which the `mkdocs.yml` is located. The Commands can be Added as aliases to ease the use.
+
+The image does not support the `mkdocs gh-deploy` command!
+
+### Building the Documentation
+
+For Bash/Zsh:
+```bash
+docker run -it --rm -v $(pwd):/repo -u $(id -u):$(id -g) toscana/mkdocs:latest mkdocs build
+```
+
+For Fish Shell:
+```fish
+docker run -it --rm -v (pwd):/repo -u (id -u):(id -g) toscana/mkdocs:latest mkdocs build
+```
+
+*Note:* It is recomended to add the `-u $(id -u):$(id -g)` part, otherwise the `site` directory will be owned by root
+
+### Serving the documentation
+
+Serving the Documentation uses the `mkdocs serve` command to allow the Real-Time editing of the files.
+
+#### Serve as Daemon
+
+For Bash/Zsh:
+```bash
+docker run --rm -d -v $(pwd):/repo -p 8000:8000 toscana/mkdocs:latest
+```
+
+For Fish Shell:
+```fish
+docker run --rm -d -v (pwd):/repo -p 8000:8000 toscana/mkdocs:latest
+```
+
+#### Serve as Command
+
+For Bash/Zsh:
+```bash
+docker run -it --rm -v $(pwd):/repo -p 8000:8000 toscana/mkdocs:latest
+```
+
+For Fish Shell:
+```fish
+docker run -it --rm -v (pwd):/repo -p 8000:8000 toscana/mkdocs:latest
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](http://mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs help` - Print this help message.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,3 @@
-# Welcome to MkDocs
+# TOSCAna
 
-For full documentation visit [mkdocs.org](http://mkdocs.org).
-
-## Commands
-
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs help` - Print this help message.
-
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+TODO: Add Text here

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,27 @@
+site_name: TOSCAna
+theme: readthedocs
+repo_name: 'StuPro-TOSCAna/TOSCAna'
+repo_url: 'https://github.com/StuPro-TOSCAna/TOSCAna'
+extra:
+  social:
+    - type: 'github'
+      link: 'https://github.com/StuPro-TOSCAna/TOSCAna'
+pages:
+    - Home: 'index.md'
+    - Developer Documentation:
+        - "Architectural Decision Records":
+            - "0000 - Use Markdown Architectural Decision Records": "adr/0000-use-markdown-architectural-decision-records.md"
+            - "0001 - Use custom model for transformations": "adr/0001-model-for-transformations.md"
+            - "0002 - Design a general plugin architecture": "adr/0002-general-plugin-architecture.md"
+            - "0003 - Use lombok in order to avoid writing boilerplate code": "adr/0003-lombok.md"
+            - "0004 - Use Spring Framework for the REST-API": "adr/0004-spring-framework.md"
+            - "0005 - Use Springfox for API documentation": "adr/0005-springfox.md"
+            - "0006 - Bash Script Generator": "adr/0006-bash-script-generator.md"
+            - "0007 - Use AWS CLI to deploy generated CloudFormation templates": "adr/0007-plugin-cloudformation-cli.md"
+            - "0008 - How to perform Kubernetes end to end tests": "adr/0008-kubernetes-end-to-end-tests.md"
+            - "0009 - CloudFoundry CLI": "adr/0009-cloudfoundry-cli.md"
+            - "0010 - How to perform Kubernetes end to end tests": "adr/0010-use-docker-java.md"
+            - "0011 - Put Integration Tests in seperate source directory": "adr/0011-put-integration-tests-in-seperate-folder.md"
+        - CLI:
+            - Architecture: 'dev/cli/cli-architecture.md'
+            - Commands: 'dev/cli/cli-commands.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: TOSCAna
-theme: readthedocs
+theme: rtd-dropdown
 repo_name: 'StuPro-TOSCAna/TOSCAna'
 repo_url: 'https://github.com/StuPro-TOSCAna/TOSCAna'
 extra:


### PR DESCRIPTION
While trying to get Sphinx running. (Does not work because of some stupid dependency issue)
I created a MkDocs configuration that we could also use to create our documentation. It also supports "Deployment" to readthedocs. (http://www.mkdocs.org/user-guide/deploying-your-docs/)

If you want to take a look a small sample with the current documentation can be seen here:
https://caarl.failwave.de