### PR TITLE
Fix Push Handling with missing slash at the end of the Registry URL

### DIFF
--- a/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/image/PushingImageBuilder.java
+++ b/server/src/main/java/org/opentosca/toscana/plugins/kubernetes/docker/image/PushingImageBuilder.java
@@ -27,10 +27,18 @@ public class PushingImageBuilder extends ImageBuilder {
 
     @Override
     public String getTag() {
+        String registryUrl = credentials.getRegistryURL();
+        if (!registryUrl.endsWith("/")) {
+            registryUrl = registryUrl + "/";
+        }
+        String username = credentials.getUsername();
+        if (!username.isEmpty()) {
+            username += "/";
+        }
         String tag = String.format(
-            "%s%s/%s:%s",
-            credentials.getRegistryURL(),
-            credentials.getUsername(),
+            "%s%s%s:%s",
+            registryUrl,
+            username,
             credentials.getRepository(),
             super.getTag()
         );


### PR DESCRIPTION
The second Attempt to this. I want to ensure that jenkins passes. (did fail last time for some weird reason)