### PR TITLE
Rework Docker Readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,36 +1,55 @@
 # TOSCAna Docker image
 
-[![Docker Build Status](https://img.shields.io/docker/build/toscana/toscana.svg)](https://hub.docker.com/r/toscana/toscana/) [![ImageLayers Size](https://img.shields.io/imagelayers/image-size/toscana/toscana/latest.svg)](https://hub.docker.com/r/toscana/toscana/) 
+[![ImageLayers Size](https://img.shields.io/imagelayers/image-size/toscana/toscana/latest.svg)](https://hub.docker.com/r/toscana/toscana/)
 
 This Docker image allows you to run the TOSCAna transformer without having to handle the dependencies.
 
 ## Running the Docker image
 
 To just launch the Application the following command can be used:
-```
+```bash
 docker run -d -p 8080:8080 toscana/toscana:latest
 ```
 
 This will launch the transformer on Port 8080. Transformation to Kubernetes and AWS will not work, because the dependencies are not enabled.
 
-### Running Docker in Docker
+### Supporting Kubernetes
 
-In order to enable the Transformation to Kubernetes the Container has to run a Instance of the Docker Daemon (aka. `dockerd`). Because Docker in Docker needs privileged access the container has to be launched using the `--privileged` flag:
+To support the Kubernetes Plugin, a running Docker daemon is required. This Requirement can either be fulfiled by running Docker in Docker (DinD) or by Linking the local Docker daemons socket via a volume.
 
+#### Option 1: Running with the Hosts `dockerd`
+
+Running with the Hosts docker daemon is achieved by linking the unix socket `/var/run/docker.sock` as a volume to the same path in the container
+
+```bash
+docker run -d -p 8080:8080 -v /var/run/docker.sock:/var/run/docker.sock toscana/toscana:latest
 ```
-docker run -d -p 8080:8080 --privileged toscana/toscana:latest
+
+#### Option 2: Running Docker in Docker
+
+You can also run a second instance of the docker daemon within the container (Docker in Docker). Because Docker in Docker needs privileged access the container has to be launched using the `--privileged` flag, if the privileged flag is missing, the image will launch but transformations to kubernetes are not possible:
+
+```bash
+docker run -d -p 8080:8080 --privileged toscana/toscana:latest-dind
 ```
 
 ### Setting AWS Credentials
 
-To use the complete range of functions of the AWS Plugin, you have to supply your AWS Credentials to the Container. This can either be done by setting the environment variables within the Container or by mounting your local AWS CLI configuration folder as a volume, this assumes you have set the credentials on the host.
+To use the complete range of functions of the AWS Plugin, you have to supply your AWS Credentials to the Container. This can be done by by mounting your local AWS CLI configuration folder as a volume, this assumes you have set the credentials on the host.
 
-#### Option 1: Mounting the AWS Folder as a volume
+#### Mounting the AWS Folder as a volume
 
-```
+```bash
 docker run -d -p 8080:8080 -v ~/.aws:/root/.aws toscana/toscana:latest
 ```
 
-#### Option 2: Setting the Credentials using environment variables
-
 ## Mount the Datadirectory as a Volume
+
+Both the DinD Image and the regular Docker Image use the folder `/toscana/data` as the datadirectory this directory can either be linked to a folder on the host:
+```bash
+docker run -d -p 8080:8080 -v <HOST-FOLDER>:/toscana/data -v /var/run/docker.sock:/var/run/docker.sock toscana/toscana:latest
+```
+Or the volume can be named by calling:
+```bash
+docker run -d -p 8080:8080 -v my_toscana_data_volume:/toscana/data -v /var/run/docker.sock:/var/run/docker.sock toscana/toscana:latest
+```

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -5,9 +5,8 @@ ADD build-toscana.sh .
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y maven git
 RUN ./build-toscana.sh
-# This image is based on the Docker in Docker image (needs --privileged to work correctly)
-# If the privileged flag is missing this image will not support kubernetes based transformations
-FROM docker:stable-dind
+# This image Uses the Docker Socket as a volume
+FROM docker:stable
 WORKDIR /toscana
 VOLUME /toscana/data
 # Mount the AWS Directory as volume (used to store Credentials)
@@ -20,4 +19,4 @@ RUN apk add --update --no-cache bash && \
 EXPOSE 8080
 ENV DATADIR="/toscana/data"
 ENV SERVER_PORT="8080"
-ENTRYPOINT ./toscana-dind-entrypoint.sh
+ENTRYPOINT ./toscana-entrypoint.sh

--- a/docker/alpine/build-toscana.sh
+++ b/docker/alpine/build-toscana.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo "Cloning TOSCAna"
+git clone https://github.com/StuPro-TOSCAna/TOSCAna.git
+
+echo "Builing TOSCAna"
+cd TOSCAna
+mvn install -DskipTests -P build
+cd ..
+cp TOSCAna/server/target/server-1.0-SNAPSHOT.jar server.jar
+rm -rf TOSCAna

--- a/docker/alpine/cleanup.sh
+++ b/docker/alpine/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Cleanup"
+apk del curl
+rm install-deps.sh cleanup.sh

--- a/docker/alpine/install-deps.sh
+++ b/docker/alpine/install-deps.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo "Installing APK Packages"
+apk add --update --no-cache curl openjdk8-jre python3
+
+echo "Installing AWS CLI"
+pip3 install awscli
+
+echo "Installing CloudFoundry CLI"
+curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
+mv cf /usr/local/bin

--- a/docker/alpine/toscana-entrypoint.sh
+++ b/docker/alpine/toscana-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Launch Toscana
+logfile=/var/log/toscana.log
+touch $logfile
+java -jar server.jar | tee -a $logfile


### PR DESCRIPTION
Resolves #621
- Add Docker Image that will use the Hosts Dockerd
-> Scripts had to be copied, because docker does not support symlinks outside of the current directory

After merging this our docker tag structure will change:
`toscana/toscana:latest` Will represent the image refering to the version to use the hosts docker socket
`toscana/toscana:latest-dind` Will represent the version with Docker in Docker (current `latest` tag)